### PR TITLE
Add docker transfer image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
             context: integration-tests
           - name: qubership-logging-transfer
             file: docker-transfer/Dockerfile
-            context: docker-transfer
+            context: ""
     runs-on: ubuntu-latest
     name: ${{ matrix.component.name }}
     steps:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -29,6 +29,9 @@ jobs:
           - name: qubership-logging-integration-tests
             file: integration-tests/Dockerfile
             context: integration-tests
+          - name: qubership-logging-transfer
+            file: docker-transfer/Dockerfile
+            context: docker-transfer
     runs-on: ubuntu-latest
     name: ${{ matrix.component.name }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Temporary Build Files
-build/
+/build/
 
 # VisualStudioCode
 .vscode/

--- a/docker-transfer/Dockerfile
+++ b/docker-transfer/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+# Collect helm charts and documentation
+COPY charts /charts
+COPY docs /docs

--- a/scripts/build/append-markdown-linter-comments.sh
+++ b/scripts/build/append-markdown-linter-comments.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Add markdown-linter comments to disable line-length and reference-links-images checks
+sed -i "1i\<!-- markdownlint-disable line-length -->\n<!-- markdownlint-disable reference-links-images -->" docs/api.md

--- a/scripts/build/append-operator-version.sh
+++ b/scripts/build/append-operator-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+OPERATOR_CRD_DIR="charts/qubership-logging-operator/crds"
+GROUP_NAME="logging.qubership.org"
+CRD_GROUP="loggingservices.${GROUP_NAME}"
+OPERATOR_ANNOTATION="logging-operator.${GROUP_NAME}/version"
+
+COMMON_LABELS="  labels:\n    app.kubernetes.io/component: qubership-logging-operator\n    app.kubernetes.io/part-of: logging"
+
+# Add annotation with the version
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find "${OPERATOR_CRD_DIR}" -name '*.yaml' -exec sed -i '' -e "/^    controller-gen.kubebuilder.io.version.*/a\\    ${OPERATOR_ANNOTATION}: ${VERSION}" {} +
+else
+  find "${OPERATOR_CRD_DIR}" -name '*.yaml' -exec sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    ${OPERATOR_ANNOTATION}: ${VERSION}" {} +
+fi
+
+# Add default labels
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find "${OPERATOR_CRD_DIR}" -name '*.yaml' -exec sed -i '' -e "/^  name: ${CRD_GROUP}/i\\${COMMON_LABELS}" {} +
+else
+  find "${OPERATOR_CRD_DIR}" -name '*.yaml' -exec sed -i "/^  name: ${CRD_GROUP}/i\\${COMMON_LABELS}" {} +
+fi


### PR DESCRIPTION
In this PR add the `docker-transfer` image to pack the Helm chart and documentation inside. Further, this image can be used to fetch the Helm chart and extend it.