### PR TITLE
Fix Warnings when starting fluentd in cloud and on VM

### DIFF
--- a/controllers/fluentd/fluentd.configmap/conf.d/fluent.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/fluent.conf
@@ -98,6 +98,13 @@
     @label @NORMAL
   </match>
 
+  # to capture fluentd logs in top level it's necessary to use <label @FLUENT_LOG>
+  <label @FLUENT_LOG>
+    <match fluent.**>
+      @type stdout
+    </match>
+  </label>
+
   # Here processed all logs that were build from some lines
   # In this section logs send after "filter-multiline.conf" so need to call last 3 filters
   <label @CONCATENATED>


### PR DESCRIPTION
added 'label' for fluentd system logs