### PR TITLE
fix: Add permissions section to Docker workflow

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         default: false
         description: 'Dry run'
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   load_config:
     name: "Load Docker Configuration"


### PR DESCRIPTION
fix: Introduce a permissions section in the Docker workflow to specify read access for contents and write access for packages.