### PR TITLE
fix: change incorrect ruby code in FluentD filters

### DIFF
--- a/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-k8s-audit.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-k8s-audit.conf
@@ -4,7 +4,7 @@
   @type record_transformer
   enable_ruby
   <record>
-    nc_audit_label '${if ((record["log"].include? "Invalid username or password") || (record["log"].include? "Successful Login") || (record["log"].include? "Successful Logout") || (record["log"].include? "Failed to look up user based on cookie")) "true" end;}'
+    nc_audit_label '${ if ( (record["log"].include? "Invalid username or password") || (record["log"].include? "Successful Login") || (record["log"].include? "Successful Logout") || (record["log"].include? "Failed to look up user based on cookie") ) then "true" end; }'
   </record>
 </filter>
 
@@ -14,17 +14,17 @@
   @type record_transformer
   enable_ruby
   <record>
-    nc_audit_label '${if ((record["log"].include? "accepted") || (record["log"].include? "mongodb")) "true" end;}'
+    nc_audit_label '${ if ( (record["log"].include? "accepted") || (record["log"].include? "mongodb") ) then "true" end; }'
   </record>
 </filter>
 
 # Filter PostgreSQL logs to parse part of these logs as audit logs
 # Parse from Pods where container name contains "patroni"
-<filter parsed.kubernetes.var.log.**patroni**>
+<filter parsed.kubernetes.var.log.**>
   @type record_transformer
   enable_ruby
   <record>
-    nc_audit_label '${if ((record["log"].include? "PG_SERVICE") || (record["log"].include? "database system is") || (record["log"].include? "AUDIT")) "true" end;}'
+    nc_audit_label '${ if (record["log"].respond_to?(:to_str) && ( (record["log"].include? "PG_SERVICE") || (record["log"].include? "database system is") || (record["log"].include? "audit_log_type") || (record["log"].include? "AUDIT") || (/logType[\": \t]*audit/.match(record["log"])) ) ) then "true" end; }'
   </record>
 </filter>
 
@@ -36,6 +36,6 @@
   @type record_transformer
   enable_ruby
   <record>
-    nc_audit_label ${record["log"].respond_to?(:to_str) && ((record["log"].include? "audit_log_type") || (/logType[":\s\t=]*audit/.match(record["log"]))) ? 'true' : 'false'}
+    nc_audit_label '${ record["log"].respond_to?(:to_str) && ( (record["log"].include? "audit_log_type") || (/logType[":\s\t=]*audit/.match(record["log"])) ) ? "true" : "false" }'
   </record>
 </filter>


### PR DESCRIPTION
# What does this MR do?

During the run FluentD I found that the run failed with errors in FluentD `filter` configurations with Ruby code inside.

## Solution

Fix the Ruby code inside the filters.