### PR TITLE
fix: bump fluentbit image

### DIFF
--- a/charts/qubership-logging-operator/templates/_helpers.tpl
+++ b/charts/qubership-logging-operator/templates/_helpers.tpl
@@ -305,7 +305,7 @@ Image can be found from:
   {{- if .Values.fluentbit.dockerImage -}}
     {{- printf "%s" .Values.fluentbit.dockerImage -}}
   {{- else -}}
-    {{- print "docker.io/fluent/fluent-bit:4.0.0" -}}
+    {{- print "docker.io/fluent/fluent-bit:4.0.1" -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
# What does this PR do?

During the FluentBit 4.0.0 start it crashed with the error:

```bash
Fluent Bit v4.0.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io
______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 
[2025/04/29 12:38:33] [ warn] [storage] Need to remove '/var/log/flb-storage//emitter.7' if it is empty
[2025/04/29 12:38:33] [engine] caught signal (SIGSEGV)
#0  0x557f86520b1e      in  memset() at _64-linux-gnu/bits/string_fortified.h:59
#1  0x557f86520b1e      in  flb_routes_mask_set_by_tag() at src/flb_routes_mask.c:44
#2  0x557f865b9e12      in  sb_append_chunk_to_segregated_backlogs() at plugins/in_storage_backlog/sb.c:305
#3  0x557f865b9e12      in  sb_segregate_chunks() at plugins/in_storage_backlog/sb.c:377
#4  0x557f86513cec      in  flb_engine_start() at src/flb_engine.c:961
#5  0x557f864ed793      in  flb_lib_worker() at src/flb_lib.c:835
#6  0x7f51284e11f4      in  ???() at ???:0
#7  0x7f512856189b      in  ???() at ???:0
#8  0xffffffffffffffff  in  ???() at ???:0
```

## Root cause

It's a bug already reported and fixed https://github.com/fluent/fluent-bit/issues/10223

## Solution

Need to bump the default FluentBit version to 4.0.1 where this bug was fixed:
https://github.com/fluent/fluent-bit/releases/tag/v4.0.1