### PR TITLE
chore: fix link-checker cache

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -22,8 +22,9 @@ jobs:
         id: restore-cache
         with:
           path: .lycheecache
-          key: cache-lychee-v1 # static key for cache (same cache for all branches).
+          key: cache-lychee-${{ github.run_id }}
           restore-keys: cache-lychee-
+          save-always: true
 
       - name: Link Checker
         id: lychee


### PR DESCRIPTION
# What does this PR do?

The cache key is now cache-lychee-${{ github.run_id }} (unique per run) with save-always: true, so each run saves the updated .lycheecache back and future runs restore the freshest one via restore-keys: cache-lychee-.
