### PR TITLE
chore: correct calico log metrics names

### DIFF
--- a/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-unparsed-log-counter.conf
+++ b/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-unparsed-log-counter.conf
@@ -1,17 +1,17 @@
 # This filter generates a Prometheus metric that counts the number of log records
 # which failed to be parsed (i.e., records where the "parse_status" field is "failed").
 [FILTER]
-    name               log_to_metrics
-    match_regex        (pods|klog).*
-    flush_interval_sec 20
-    tag                parse_error_metrics
-    metric_mode        counter
-    metric_name        parse_error_total
-    metric_description Total number of parse errors
-    label_field        namespace
-    label_field        pod
-    label_field        container
-    Regex              parse_status ^failed$
+    name                 log_to_metrics
+    match_regex          (pods|klog).*
+    flush_interval_sec   20
+    tag                  parse_error_metrics
+    metric_mode          counter
+    metric_name          parse_error_total
+    metric_description   Total number of parse errors
+    label_field          namespace
+    label_field          pod
+    label_field          container
+    Regex                parse_status ^failed$
 # This filter generates a Prometheus metric that counts the number of syn packets sent without response,
 # based on log records from calico-node pods.
 [FILTER]
@@ -20,8 +20,10 @@
     Flush_interval_sec   20
     Tag                  calico
     Metric_mode          counter
-    Metric_name          calico_syn_packets_total
-    Metric_Description   Total number of syn packets sent without response
+    Metric_name          packets_total
+    Metric_namespace     calico
+    Metric_subsystem     syn
+    Metric_Description   Total number of SYN packets messages in Calico logs
     label_field          src_ip
     label_field          dst_ip
     label_field          src_pod

--- a/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-unparsed-log-counter.conf
+++ b/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-unparsed-log-counter.conf
@@ -20,8 +20,10 @@
     Flush_interval_sec   20
     Tag                  calico
     Metric_mode          counter
-    Metric_name          calico_syn_packets_total
-    Metric_Description   Total number of syn packets sent without response
+    Metric_name          packets_total
+    Metric_namespace     calico
+    Metric_subsystem     syn
+    Metric_Description   Total number of SYN packets messages in Calico logs
     label_field          src_ip
     label_field          dst_ip
     label_field          src_pod

--- a/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-calico-packets.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-calico-packets.conf
@@ -24,7 +24,7 @@
   <metric>
     name calico_syn_packets_total
     type counter
-    desc "The total number of SYN packets received by calico signifying connection issues."
+    desc "The total number of SYN packets messages in Calico logs"
     <labels>
       namespace ${namespace}
       pod ${pod}


### PR DESCRIPTION
# What does this PR do?
Removed `log_metric_counter` prefix from metric `calico_syn_packets_total`  in fluentbit.
