### PR TITLE
fix: fix for go linter

### DIFF
--- a/api/doc.go
+++ b/api/doc.go
@@ -1,0 +1,17 @@
+// Copyright NetCracker Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package api is the root package for the api module. API types live under ./v1;
+// this file exists so tools that load the module path as a Go package (e.g. golangci-lint in super-linter GO_MODULES) succeed.
+package api

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,17 @@
+// Copyright NetCracker Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package qubershiploggingoperator is the module root. Executable code lives under ./cmd, ./api, and ./controllers;
+// this file exists so tools that load the module path as a Go package (e.g. golangci-lint in super-linter GO_MODULES) succeed.
+package qubershiploggingoperator


### PR DESCRIPTION
# What does this PR do?

Fixes the fails of go linter happening in case of changes in go.mod files.
