### PR TITLE
feat: add probes for logging-operator

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -271,7 +271,7 @@ jobs:
             exit 1
           fi
           echo "Attempt $attempt/$max_attempts: Checking logging-operator pod status..."
-          pod=$(kubectl get pod -l name=logging-service-operator -n ${{ env.namespace }} -o jsonpath='{.items[0]}')
+          pod=$(kubectl get pod -l name=logging-operator -n ${{ env.namespace }} -o jsonpath='{.items[0]}')
           phase=$(echo "$pod" | jq -r '.status.phase')
           ready=$(echo "$pod" | jq -r '.status.conditions[] | select(.type == "Ready") | .status')
           scheduled=$(echo "$pod" | jq -r '.status.conditions[] | select(.type == "PodScheduled") | .status')

--- a/charts/qubership-logging-operator/README.md
+++ b/charts/qubership-logging-operator/README.md
@@ -2,9 +2,20 @@
 
 # qubership-logging-operator
 
-![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 14.30.0](https://img.shields.io/badge/AppVersion-14.30.0-informational?style=flat-square)
+
+
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 14.30.0](https://img.shields.io/badge/AppVersion-14.30.0-informational?style=flat-square) 
 
 A Helm chart for qubership-logging-operator
+
+
+
+
+
+
+
+
+
 
 ## Values
 
@@ -188,7 +199,7 @@ not set
 			<td>fluentbit.aggregator.customFilterConf</td>
 			<td>string</td>
 			<td><pre lang="json">
-null
+""
 </pre>
 </td>
 			<td>FluentBit custom filter configuration.</td>
@@ -197,7 +208,7 @@ null
 			<td>fluentbit.aggregator.customInputConf</td>
 			<td>string</td>
 			<td><pre lang="json">
-null
+""
 </pre>
 </td>
 			<td>FluentBit custom input configuration.</td>
@@ -215,7 +226,7 @@ null
 			<td>fluentbit.aggregator.customOutputConf</td>
 			<td>string</td>
 			<td><pre lang="json">
-null
+""
 </pre>
 </td>
 			<td>FluentBit custom output configuration.</td>
@@ -713,7 +724,7 @@ true
 			<td>fluentbit.customFilterConf</td>
 			<td>string</td>
 			<td><pre lang="json">
-null
+""
 </pre>
 </td>
 			<td>FluentBit custom filter configuration.</td>
@@ -722,7 +733,7 @@ null
 			<td>fluentbit.customInputConf</td>
 			<td>string</td>
 			<td><pre lang="json">
-null
+""
 </pre>
 </td>
 			<td>FluentBit custom input configuration.</td>
@@ -740,7 +751,7 @@ null
 			<td>fluentbit.customOutputConf</td>
 			<td>string</td>
 			<td><pre lang="json">
-null
+""
 </pre>
 </td>
 			<td>FluentBit custom output configuration.</td>
@@ -1365,26 +1376,6 @@ not set
 			<td>Allow to add filter to parse json of Kubernetes events logs from Cloud Events Reader</td>
 		</tr>
 		<tr>
-			<td>fluentd.configmapReload</td>
-			<td>object</td>
-			<td><pre lang="json">
-{
-  "resources": {
-    "limits": {
-      "cpu": "50m",
-      "memory": "50Mi"
-    },
-    "requests": {
-      "cpu": "10m",
-      "memory": "10Mi"
-    }
-  }
-}
-</pre>
-</td>
-			<td>A docker image to use for fluent daemon set. dockerImage: ghcr.io/netcracker/qubership-fluentd:main</td>
-		</tr>
-		<tr>
 			<td>fluentd.configmapReload.resources</td>
 			<td>object</td>
 			<td><pre lang="json">
@@ -1484,6 +1475,39 @@ true
 			<td>Enable input for Kubernetes audit logs from /var/log/kubernetes/kube-apiserver-audit.log and /var/log/kubernetes/audit.log.</td>
 		</tr>
 		<tr>
+			<td>fluentd.output</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "http": {
+    "auth": {},
+    "compress": "gzip",
+    "enabled": false,
+    "host": "",
+    "routing": {
+      "enabled": false
+    },
+    "tls": {
+      "enabled": false
+    }
+  },
+  "loki": {
+    "auth": {},
+    "enabled": false,
+    "labelsMapping": "stream $.stream\ncontainer $.container\npod $.pod\nnamespace $.namespace\nlevel $.level\nhostname $.hostname\nnodename $.kubernetes_host\nrequest_id $.request_id\ntenant_id $.tenant_id\naddressTo $.addressTo\noriginating_bi_id $.originating_bi_id\nspanId $.spanId",
+    "staticLabels": "{\"job\":\"fluentd\"}",
+    "tls": {
+      "allCiphers": true,
+      "enabled": false,
+      "noVerify": false
+    }
+  }
+}
+</pre>
+</td>
+			<td>Output configuration.</td>
+		</tr>
+		<tr>
 			<td>fluentd.output.http</td>
 			<td>object</td>
 			<td><pre lang="json">
@@ -1567,6 +1591,25 @@ false
 </pre>
 </td>
 			<td>Allows enabling TLS for Http output.</td>
+		</tr>
+		<tr>
+			<td>fluentd.output.loki</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "auth": {},
+  "enabled": false,
+  "labelsMapping": "stream $.stream\ncontainer $.container\npod $.pod\nnamespace $.namespace\nlevel $.level\nhostname $.hostname\nnodename $.kubernetes_host\nrequest_id $.request_id\ntenant_id $.tenant_id\naddressTo $.addressTo\noriginating_bi_id $.originating_bi_id\nspanId $.spanId",
+  "staticLabels": "{\"job\":\"fluentd\"}",
+  "tls": {
+    "allCiphers": true,
+    "enabled": false,
+    "noVerify": false
+  }
+}
+</pre>
+</td>
+			<td>Loki output configuration.</td>
 		</tr>
 		<tr>
 			<td>fluentd.output.loki.auth</td>
@@ -2042,7 +2085,7 @@ false
 false
 </pre>
 </td>
-			<td>Establish a STARTTLS protected session.</td>
+			<td>Establish a STAR TLS protected session.</td>
 		</tr>
 		<tr>
 			<td>graylog.authProxy.ldap.url</td>
@@ -2848,6 +2891,24 @@ false
 			<td>Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. Ref: https://kubernetes.io/docs/user-guide/labels</td>
 		</tr>
 		<tr>
+			<td>livenessProbe</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "failureThreshold": 3,
+  "httpGet": {
+    "path": "/health",
+    "port": 8081
+  },
+  "initialDelaySeconds": 5,
+  "periodSeconds": 10,
+  "timeoutSeconds": 5
+}
+</pre>
+</td>
+			<td>Liveness probe for logging-operator</td>
+		</tr>
+		<tr>
 			<td>logLevel</td>
 			<td>string</td>
 			<td><pre lang="json">
@@ -2884,7 +2945,7 @@ false
 }
 </pre>
 </td>
-			<td>Pod monitor for qubership-logging-operator</td>
+			<td>Pod monitor for logging-operator</td>
 		</tr>
 		<tr>
 			<td>podMonitor.scrapeInterval</td>
@@ -2921,7 +2982,7 @@ false
 }
 </pre>
 </td>
-			<td>qubership-logging-operator pprof</td>
+			<td>logging-operator pprof</td>
 		</tr>
 		<tr>
 			<td>pprof.containerPort</td>
@@ -2939,7 +3000,7 @@ false
 true
 </pre>
 </td>
-			<td>Indicates if qubership-logging-operator has pprof enabled.</td>
+			<td>Indicates if logging-operator has pprof enabled.</td>
 		</tr>
 		<tr>
 			<td>pprof.service</td>
@@ -3001,6 +3062,46 @@ true
 </td>
 			<td>Type of pprof service</td>
 		</tr>
+		<tr>
+			<td>readinessProbe</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "failureThreshold": 3,
+  "httpGet": {
+    "path": "/ready",
+    "port": 8081
+  },
+  "initialDelaySeconds": 3,
+  "periodSeconds": 10,
+  "timeoutSeconds": 5
+}
+</pre>
+</td>
+			<td>Readiness probe for logging-operator</td>
+		</tr>
+		<tr>
+			<td>resources</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "limits": {
+    "cpu": "150m",
+    "memory": "100Mi"
+  },
+  "requests": {
+    "cpu": "25m",
+    "memory": "50Mi"
+  }
+}
+</pre>
+</td>
+			<td>Resources for logging-operator</td>
+		</tr>
 	</tbody>
 </table>
+
+
+
+
 

--- a/charts/qubership-logging-operator/templates/_helpers.tpl
+++ b/charts/qubership-logging-operator/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Add Authorization header if Bearer Token authorization enabled for http output i
 name: {{ $name }}
 app.kubernetes.io/name: {{ $name }}
 app.kubernetes.io/component: {{ $component }}
-app.kubernetes.io/part-of: logging
+app.kubernetes.io/part-of: logging-service
 app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
 {{- end -}}
 

--- a/charts/qubership-logging-operator/templates/operator/certificate.yaml
+++ b/charts/qubership-logging-operator/templates/operator/certificate.yaml
@@ -4,7 +4,7 @@ kind: Certificate
 metadata:
   name: logging-self-signed-ca-certificate
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-self-signed-ca-certificate" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-self-signed-ca-certificate" "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/clusterrole.yaml
+++ b/charts/qubership-logging-operator/templates/operator/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" (printf "%s-logging-operator" .Release.Namespace) "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" (printf "%s-logging-operator" .Release.Namespace) "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
 rules:
   # Need to get list of nodes and them runtimes to discover which runtime type should use

--- a/charts/qubership-logging-operator/templates/operator/clusterrolebinding.yaml
+++ b/charts/qubership-logging-operator/templates/operator/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" (printf "%s-logging-operator" .Release.Namespace) "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" (printf "%s-logging-operator" .Release.Namespace) "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount

--- a/charts/qubership-logging-operator/templates/operator/clusterrolebinding.yaml
+++ b/charts/qubership-logging-operator/templates/operator/clusterrolebinding.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "logging.extraLabels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: logging-service-operator
+    name: logging-operator
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/qubership-logging-operator/templates/operator/deployment.yaml
+++ b/charts/qubership-logging-operator/templates/operator/deployment.yaml
@@ -53,25 +53,22 @@ spec:
           args:
             - '--pprof-enable={{ .Values.pprof.install }}'
             {{- if .Values.pprof.install }}
-            {{- if .Values.pprof.service.port }}
             - '--pprof-address=:{{ .Values.pprof.service.port }}'
-            {{- end }}
             {{- end }}
           imagePullPolicy: IfNotPresent
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:
-            - name: "http-metrics"
-              containerPort: 8383
-              protocol: "TCP"
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 8081
+              name: http
+              protocol: TCP
             {{- if .Values.pprof.install }}
-            {{- if .Values.pprof.containerPort }}
-            {{- if .Values.pprof.service.portName }}
             - containerPort: {{ .Values.pprof.containerPort }}
               name: {{ .Values.pprof.service.portName }}
               protocol: TCP
-            {{- end }}
-            {{- end }}
             {{- end }}
           env:
             - name: WATCH_NAMESPACE

--- a/charts/qubership-logging-operator/templates/operator/deployment.yaml
+++ b/charts/qubership-logging-operator/templates/operator/deployment.yaml
@@ -19,6 +19,8 @@ spec:
   selector:
     matchLabels:
       name: logging-service-operator
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -57,12 +59,7 @@ spec:
             {{- end }}
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              cpu: "150m"
-              memory: "100Mi"
-            requests:
-              cpu: "25m"
-              memory: "50Mi"
+            {{- toYaml .Values.resources | nindent 12 }}
           ports:
             - name: "http-metrics"
               containerPort: 8383
@@ -90,11 +87,11 @@ spec:
               value: {{ .Values.skipMetricsService | quote }}
             {{- end }}
             - name: SCRAPE_INTERVAL
-              value: {{ default "30s" .Values.podMonitor.scrapeInterval }}
+              value: {{ .Values.podMonitor.scrapeInterval | default "30s" }}
             - name: SCRAPE_TIMEOUT
-              value: {{ default "10s" .Values.podMonitor.scrapeTimeout }}
+              value: {{ .Values.podMonitor.scrapeTimeout | default "10s" }}
             - name: LOG_LEVEL
-              value: {{ default "info" .Values.logLevel }}
+              value: {{ .Values.logLevel | default "info" }}
             {{- if .Values.graylog.install }}
             - name: GRAYLOG_USERNAME
               valueFrom:
@@ -112,5 +109,8 @@ spec:
                   key: elasticsearchHost
                   name: {{ default "graylog-secret" .Values.graylog.graylogSecretName }}
             {{- end }}
-  strategy:
-    type: Recreate
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+

--- a/charts/qubership-logging-operator/templates/operator/deployment.yaml
+++ b/charts/qubership-logging-operator/templates/operator/deployment.yaml
@@ -1,11 +1,11 @@
-{{- $instance := cat "logging-service-operator-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+{{- $instance := cat "logging-operator-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
 {{- $image := include "logging-operator.image" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: logging-service-operator
+  name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-service-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
     app.kubernetes.io/instance: {{ $instance }}
     app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
     app.kubernetes.io/technology: go
@@ -18,13 +18,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: logging-service-operator
+      name: logging-operator
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        {{- include "logging.labels" (dict "ctx" . "name" "logging-service-operator" "component" "logging-operator") | nindent 8 }}
+        {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 8 }}
         app.kubernetes.io/instance: {{ $instance }}
         app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
         app.kubernetes.io/technology: go
@@ -34,7 +34,7 @@ spec:
         {{ toYaml .Values.annotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: logging-service-operator
+      serviceAccountName: logging-operator
       {{- if and .Values.nodeSelectorKey .Values.nodeSelectorValue }}
       nodeSelector:
         {{ .Values.nodeSelectorKey | indent 8 }}: {{ .Values.nodeSelectorValue }}

--- a/charts/qubership-logging-operator/templates/operator/deployment.yaml
+++ b/charts/qubership-logging-operator/templates/operator/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "operator") | nindent 4 }}
     app.kubernetes.io/instance: {{ $instance }}
     app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
     app.kubernetes.io/technology: go
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 8 }}
+        {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "operator") | nindent 8 }}
         app.kubernetes.io/instance: {{ $instance }}
         app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
         app.kubernetes.io/technology: go

--- a/charts/qubership-logging-operator/templates/operator/issuer-ca.yaml
+++ b/charts/qubership-logging-operator/templates/operator/issuer-ca.yaml
@@ -4,7 +4,7 @@ kind: Issuer
 metadata:
   name: logging-ca-issuer
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-ca-issuer" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-ca-issuer" "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/issuer-self-signed.yaml
+++ b/charts/qubership-logging-operator/templates/operator/issuer-self-signed.yaml
@@ -4,7 +4,7 @@ kind: Issuer
 metadata:
   name: logging-self-signed-issuer
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-self-signed-issuer" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-self-signed-issuer" "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/loggingservice.observability.netcracker.com.yaml
+++ b/charts/qubership-logging-operator/templates/operator/loggingservice.observability.netcracker.com.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.name }}
   labels:
     {{- include "logging.labels" (dict "ctx" . "name" .Values.name "component" "logging-operator") | nindent 4 }}
-    app.kubernetes.io/processed-by-operator: logging-service-operator
+    app.kubernetes.io/processed-by-operator: logging-operator
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/loggingservice.observability.netcracker.com.yaml
+++ b/charts/qubership-logging-operator/templates/operator/loggingservice.observability.netcracker.com.yaml
@@ -3,7 +3,7 @@ kind: LoggingService
 metadata:
   name: {{ .Values.name }}
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" .Values.name "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" .Values.name "component" "operator") | nindent 4 }}
     app.kubernetes.io/processed-by-operator: logging-operator
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}

--- a/charts/qubership-logging-operator/templates/operator/role.yaml
+++ b/charts/qubership-logging-operator/templates/operator/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/role.yaml
+++ b/charts/qubership-logging-operator/templates/operator/role.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: logging-service-operator
+  name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-service-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/rolebinding.yaml
+++ b/charts/qubership-logging-operator/templates/operator/rolebinding.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: logging-service-operator
+  name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-service-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:
@@ -11,8 +11,8 @@ metadata:
   {{- end }}
 subjects:
 - kind: ServiceAccount
-  name: logging-service-operator
+  name: logging-operator
 roleRef:
   kind: Role
-  name: logging-service-operator
+  name: logging-operator
   apiGroup: rbac.authorization.k8s.io

--- a/charts/qubership-logging-operator/templates/operator/rolebinding.yaml
+++ b/charts/qubership-logging-operator/templates/operator/rolebinding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 metadata:
   name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/service.yaml
+++ b/charts/qubership-logging-operator/templates/operator/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "operator") | nindent 4 }}
     {{- if .Values.pprof.service.labels }}
     {{- include "logging.extraLabels" (dict "ctx" . "extraLabels" .Values.pprof.service.labels) | nindent 4 }}
     {{- end }}

--- a/charts/qubership-logging-operator/templates/operator/service.yaml
+++ b/charts/qubership-logging-operator/templates/operator/service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: logging-service-operator
+  name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-service-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
     {{- if .Values.pprof.service.labels }}
     {{- include "logging.extraLabels" (dict "ctx" . "extraLabels" .Values.pprof.service.labels) | nindent 4 }}
     {{- end }}
@@ -20,5 +20,5 @@ spec:
       targetPort: {{ .Values.pprof.containerPort }}
       protocol: TCP
   selector:
-    name: logging-service-operator
+    name: logging-operator
 {{- end }}

--- a/charts/qubership-logging-operator/templates/operator/serviceaccount.yaml
+++ b/charts/qubership-logging-operator/templates/operator/serviceaccount.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: logging-service-operator
+  name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-service-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/templates/operator/serviceaccount.yaml
+++ b/charts/qubership-logging-operator/templates/operator/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: logging-operator
   labels:
-    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "logging-operator") | nindent 4 }}
+    {{- include "logging.labels" (dict "ctx" . "name" "logging-operator" "component" "operator") | nindent 4 }}
     {{- include "logging.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:

--- a/charts/qubership-logging-operator/values.yaml
+++ b/charts/qubership-logging-operator/values.yaml
@@ -21,7 +21,7 @@ ipv6: false
 # @default -- "containerd"
 # containerRuntimeType: containerd
 
-# -- Image of qubership-logging-operator
+# -- Image of logging-operator
 # operatorImage: ghcr.io/netcracker/qubership-logging-operator:main
 
 # -- The log level of operator logs.
@@ -45,9 +45,9 @@ annotations: {}
 # Ref: https://kubernetes.io/docs/user-guide/labels
 labels: {}
 
-# -- qubership-logging-operator pprof
+# -- logging-operator pprof
 pprof:
-  # -- Indicates if qubership-logging-operator has pprof enabled.
+  # -- Indicates if logging-operator has pprof enabled.
   install: true
   # -- Port of pprof which use in container
   containerPort: 9180
@@ -69,12 +69,41 @@ pprof:
 # -- Allow disabling create MetricsService during deploy
 # skipMetricsService: false
 
-# -- Pod monitor for qubership-logging-operator
+# -- Resources for logging-operator
+resources:
+  requests:
+    cpu: 25m
+    memory: 50Mi
+  limits:
+    cpu: 150m
+    memory: 100Mi
+
+# -- Pod monitor for logging-operator
 podMonitor:
   # -- Allow change metrics scrape timeout
   scrapeTimeout: 10s
   # -- Allow change metrics scrape interval
   scrapeInterval: 30s
+
+# -- Liveness probe for logging-operator
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Readiness probe for logging-operator
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8081
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
 
 # -- Mandatory values for Graylog.
 # @default -- {}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -120,7 +120,7 @@ func main() {
 				Protocol:   v1.ProtocolTCP,
 				TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
 		}
-		serviceName := "logging-service-operator-metrics"
+		serviceName := "logging-operator-metrics"
 		label := utils.MergeLabels(
 			utils.ResourceLabels(serviceName, "logging-operator"),
 			map[string]string{"app.kubernetes.io/instance": utils.GetInstanceLabel(serviceName, namespace)},
@@ -128,7 +128,7 @@ func main() {
 		// Create Service object to expose the metrics port(s).
 		service := &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "logging-service-operator-metrics",
+				Name:      "logging-operator-metrics",
 				Namespace: namespace,
 				Labels:    label,
 			},

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -33,8 +33,7 @@ import (
 var (
 	scheme            = apiruntime.NewScheme()
 	logger            = utils.Logger("cmd")
-	metricsHost       = "0.0.0.0"
-	metricsPort int32 = 8383
+	metricsPort int32 = 8080
 )
 
 func init() {
@@ -50,11 +49,17 @@ func printVersion() {
 }
 
 func main() {
-	var pprofAddr string
-	var pprofEnabled bool
+	var metricsAddr, probeAddr, pprofAddr string
+	var enableLeaderElection, pprofEnabled bool
 
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&pprofEnabled, "pprof-enable", true, "Enable pprof.")
 	flag.StringVar(&pprofAddr, "pprof-address", ":9180", "The pprof address.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+
 	printVersion()
 	logf.SetLogger(logger)
 	namespace, found := os.LookupEnv("WATCH_NAMESPACE")
@@ -63,10 +68,13 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme: scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-		},
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		HealthProbeBindAddress: probeAddr,
+		ReadinessEndpointName:  "/ready",
+		LivenessEndpointName:   "/health",
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "asd23ha2.logging.netcracker.com",
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				namespace: {},
@@ -94,7 +102,11 @@ func main() {
 	if !found || skipMetricsService != "true" {
 		// Add to the below struct any other metrics ports you want to expose.
 		servicePorts := []v1.ServicePort{
-			{Port: metricsPort, Name: "http-metrics", Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
+			{
+				Port:       metricsPort,
+				Name:       "http-metrics",
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
 		}
 		serviceName := "logging-service-operator-metrics"
 		label := utils.MergeLabels(

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -18,6 +18,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -59,8 +60,10 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.Parse()
 
 	printVersion()
+
 	logf.SetLogger(logger)
 	namespace, found := os.LookupEnv("WATCH_NAMESPACE")
 	if !found {
@@ -83,6 +86,15 @@ func main() {
 	})
 	if err != nil {
 		logger.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
+		logger.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("ready", healthz.Ping); err != nil {
+		logger.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 

--- a/controllers/utils/labels.go
+++ b/controllers/utils/labels.go
@@ -14,7 +14,7 @@ const (
 	// ManagedByOperator is the value for app.kubernetes.io/managed-by on resources created by the operator.
 	ManagedByOperator = "logging-operator"
 	// OperatorDeploymentName is the name of the logging-operator Deployment; used for app.kubernetes.io/managed-by-operator.
-	OperatorDeploymentName = "logging-service-operator"
+	OperatorDeploymentName = "logging-operator"
 )
 
 // CommonLabels returns the labels applied to all resources (part-of, managed-by, managed-by-operator).

--- a/controllers/utils/service-monitor.go
+++ b/controllers/utils/service-monitor.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	ErrPodMonitorNotPresent = fmt.Errorf("no PodMonitor registered with the API")
-	SelectorLabels          = map[string]string{"name": "logging-service-operator"}
+	SelectorLabels          = map[string]string{"name": "logging-operator"}
 )
 
 // CreatePodMonitors creates PodMonitors objects based on an array of Pod objects.

--- a/controllers/utils/status_integration_test.go
+++ b/controllers/utils/status_integration_test.go
@@ -189,8 +189,8 @@ func TestRemoveTemporaryStatuses_Integration(t *testing.T) {
 		// - ComponentPendingStatus/Failed (keep)
 		conditions := []loggingService.LoggingServiceCondition{
 			{Reason: LoggingServiceStatus, Type: InProgress},
-			{Reason: GraylogStatus, Type: Success},           // Should be removed (not Failed, not LoggingServiceStatus)
-			{Reason: ComponentPendingStatus, Type: Failed},    // Should be kept
+			{Reason: GraylogStatus, Type: Success},         // Should be removed (not Failed, not LoggingServiceStatus)
+			{Reason: ComponentPendingStatus, Type: Failed}, // Should be kept
 		}
 		updater, cr := newTestStatusUpdaterWithPatch(conditions, loggingService.LoggingServiceSpec{})
 		updater.RemoveTemporaryStatuses()

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -392,7 +392,7 @@ to handle Graylog’s load (when deploying Graylog in the cloud).
 Installation consists of the following steps:
 
 1. Obtain the helm chart.
-  
+
    ```sh
    git clone https://github.com/Netcracker/qubership-logging-operator.git
    cd logging-operator/charts/logging-operator
@@ -432,7 +432,7 @@ Installation consists of the following steps:
    * `opensearch_user` and `opensearch_password`: credentials for OpenSearch user
    * `opensearch_host`: the address of OpenSearch (usually `opensearch.opensearch`)
    * `opensearch_port`: opensearch port (default `9200`)
-  
+
 3. Install the Helm chart from the local repository.
 
    ```sh
@@ -467,7 +467,7 @@ Installation consists of the following steps:
    NAME                                               READY     STATUS             RESTARTS   AGE
    events-reader-64d6698bb8-tfp5l                     1/1       Running            0          1m
    logging-fluentd-sh86l                              1/1       Running            0          1m
-   logging-service-operator-7b586d8767-lpwzl          1/1       Running            0          1m
+   logging-operator-7b586d8767-lpwzl          1/1       Running            0          1m
    ```
 
    All pods should enter the `Running` and `Ready` state within a few minutes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -564,10 +564,10 @@ There are some issues in FluentBit and FluentD that could lead to parse parts of
 For example, from the log:
 
 ```bash
-[2024-09-30T04:59:40.498] [DEBUG] [request_id=1a04d001-37e6-418b-bc7f-4904d4dfc753] [tenant_id=-] [thread=main-8e36d] 
-[class=mongo:storage.go:236] [traceId=0000000000000000176d565380a60f8b] [spanId=04546e4d3320dc9b] try to delete objects 
-from certificates by filter map[$and:[map[meta.status:map[$ne:trusted]] map[$or:[map[meta.deactivatedAt:map[$lte:2024-08-31 
-04:59:40.498507159 +0000 UTC m=+6199354.549415617]] map[details.validTo:map[$lte:2024-08-31 04:59:40.498507159 +0000 UTC 
+[2024-09-30T04:59:40.498] [DEBUG] [request_id=1a04d001-37e6-418b-bc7f-4904d4dfc753] [tenant_id=-] [thread=main-8e36d]
+[class=mongo:storage.go:236] [traceId=0000000000000000176d565380a60f8b] [spanId=04546e4d3320dc9b] try to delete objects
+from certificates by filter map[$and:[map[meta.status:map[$ne:trusted]] map[$or:[map[meta.deactivatedAt:map[$lte:2024-08-31
+04:59:40.498507159 +0000 UTC m=+6199354.549415617]] map[details.validTo:map[$lte:2024-08-31 04:59:40.498507159 +0000 UTC
 m=+6199354.549415617]]]]]]
 ```
 
@@ -935,10 +935,10 @@ We highly recommend to use TCP connection from FluentD/FluentBit to Graylog.
 If you need to use UDP connection for some reasons, you can try to set smaller value in Graylog buffer section
 in FluentD configuration. To do that you need to:
 
-1. Scale logging-service-operator to 0 replicas (because it can rewrite your changes in Fluentd Configuration).
+1. Scal to 0 replicas (because it can rewrite your changes in Fluentd Configuration).
 
     ```bash
-    kubectl scale -n <namespace> deployment logging-service-operator --replicas=0
+    kubectl scale -n <namespace> deployment logging-operator --replicas=0
     ```
 
 2. Edit configmap `logging-fluentd`.
@@ -1014,11 +1014,11 @@ FluentBit stuck and do not send any logs.
 First of all, check that you upgraded to the latest version of Logging.
 If you want to solve problem manually, follow steps below (it is temporary solution):
 
-1. Make sure that you are connected to the Cloud. Scale `logging-service-operator` deployment to 0 replicas with the
+1. Make sure that you are connected to the Cloud. Scale `logging-operator` deployment to 0 replicas with the
    command:
 
    ```bash
-   kubectl scale -n logging deployment logging-service-operator --replicas=1
+   kubectl scale -n logging deployment logging-operator --replicas=1
    ```
 
 2. Modify ConfigMap `logging-fluentbit`:

--- a/test/robot-tests/src/tests/lib/LoggingLibrary.py
+++ b/test/robot-tests/src/tests/lib/LoggingLibrary.py
@@ -16,7 +16,7 @@ def add_security_context_to_deployment(path_to_file, namespace):
     pods = k8s_lib.get_pods(namespace)
     security_context = None
     for pod in pods:
-        if 'logging-service-operator' in pod.metadata.name:
+        if 'logging-operator' in pod.metadata.name:
             security_context = pod.spec.security_context
             break
     if security_context is None:


### PR DESCRIPTION
# What does this PR do?

Add liveness and readiness probes for logging-operator.

Changes:
- add logic in the operator in `main.go` to enable both probes
- probes expose using endpoints `/ready` and `/health`
- ports for metrics and health were aligned with other operators:
  -  metrics port - `8080`
  -  health port changed from `8383` to `8081`

Additional changes:
- Apply `go fmt` and `go vet` to the source code
- Move hardcoded in Helm templates in `values.yaml`
