### PR TITLE
feat: add inline creds for outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ venv/
 
 # MkDocs
 site/
+
+# Claude Code local settings
+.claude/

--- a/charts/qubership-logging-operator/templates/_helpers.tpl
+++ b/charts/qubership-logging-operator/templates/_helpers.tpl
@@ -44,6 +44,8 @@ Add Authorization header if Bearer Token authorization enabled for http output i
 {{- end }}
 {{- if and $http.auth $http.auth.token $http.auth.token.name $http.auth.token.key }}
   {{- $_ := set $headers "Authorization" "Bearer #{ENV['HTTP_TOKEN']}" }}
+{{- else if and $http.auth $http.auth.credentials $http.auth.credentials.token }}
+  {{- $_ := set $headers "Authorization" "Bearer #{ENV['HTTP_TOKEN']}" }}
 {{- end }}
 {{- toYaml $headers }}
 {{- end -}}
@@ -496,5 +498,75 @@ MongoDB 4.4 image.
   {{- else -}}
     {{- /* # renovate: datasource=docker depName=mongo */ -}}
     {{- print "docker.io/mongo:4.4.30" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the secret name for output auth credentials.
+Accepts a dict with "auth" (the auth config) and "default" (default secret name).
+*/}}
+{{- define "logging.output.auth.secretName" -}}
+  {{- if and .auth.credentials .auth.credentials.secretName -}}
+    {{- .auth.credentials.secretName -}}
+  {{- else -}}
+    {{- .default -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Check if output auth credentials should create a secret.
+Returns "true" if credentials are set AND no explicit secret refs override them.
+Accepts a dict with "auth" (the auth config).
+*/}}
+{{- define "logging.output.auth.shouldCreateSecret" -}}
+  {{- if .auth.credentials -}}
+    {{- $hasTokenRef := and .auth.token .auth.token.name .auth.token.key -}}
+    {{- $hasUserRef := and .auth.user .auth.user.name .auth.user.key .auth.password .auth.password.name .auth.password.key -}}
+    {{- if not (or $hasTokenRef $hasUserRef) -}}
+      {{- if or .auth.credentials.token (and .auth.credentials.username .auth.credentials.password) -}}
+true
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Render the CRD-compatible auth block for Loki outputs.
+Accepts a dict with "auth" (the auth config) and "default" (default secret name).
+*/}}
+{{- define "logging.output.auth" -}}
+  {{- if .auth.token -}}
+    {{- if and .auth.token.name .auth.token.key }}
+auth:
+  token:
+    name: {{ .auth.token.name }}
+    key: {{ .auth.token.key }}
+    {{- end -}}
+  {{- else if and .auth.user .auth.password -}}
+    {{- if and .auth.user.name .auth.user.key .auth.password.name .auth.password.key }}
+auth:
+  user:
+    name: {{ .auth.user.name }}
+    key: {{ .auth.user.key }}
+  password:
+    name: {{ .auth.password.name }}
+    key: {{ .auth.password.key }}
+    {{- end -}}
+  {{- else if .auth.credentials -}}
+    {{- $secretName := include "logging.output.auth.secretName" . -}}
+    {{- if .auth.credentials.token }}
+auth:
+  token:
+    name: {{ $secretName }}
+    key: token
+    {{- else if and .auth.credentials.username .auth.credentials.password }}
+auth:
+  user:
+    name: {{ $secretName }}
+    key: username
+  password:
+    name: {{ $secretName }}
+    key: password
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/qubership-logging-operator/templates/operator/loggingservice.observability.netcracker.com.yaml
+++ b/charts/qubership-logging-operator/templates/operator/loggingservice.observability.netcracker.com.yaml
@@ -459,24 +459,7 @@ spec:
         tenant: {{ .Values.fluentd.output.loki.tenant }}
         {{- end }}
         {{- if .Values.fluentd.output.loki.auth }}
-        {{- if .Values.fluentd.output.loki.auth.token }}
-        {{- if and .Values.fluentd.output.loki.auth.token.name .Values.fluentd.output.loki.auth.token.key }}
-        auth:
-          token:
-            name: {{ .Values.fluentd.output.loki.auth.token.name }}
-            key: {{ .Values.fluentd.output.loki.auth.token.key }}
-        {{- end }}
-        {{- else if and .Values.fluentd.output.loki.auth.user  .Values.fluentd.output.loki.auth.password }}
-        {{- if and .Values.fluentd.output.loki.auth.user.name .Values.fluentd.output.loki.auth.user.key .Values.fluentd.output.loki.auth.password.name .Values.fluentd.output.loki.auth.password.key }}
-        auth:
-          user:
-            name: {{ .Values.fluentd.output.loki.auth.user.name }}
-            key: {{ .Values.fluentd.output.loki.auth.user.key }}
-          password:
-            name: {{ .Values.fluentd.output.loki.auth.password.name }}
-            key: {{ .Values.fluentd.output.loki.auth.password.key }}
-        {{- end }}
-        {{- end }}
+        {{- include "logging.output.auth" (dict "auth" .Values.fluentd.output.loki.auth "default" (printf "%s-fluentd-loki-auth" .Release.Name)) | nindent 8 }}
         {{- end }}
         {{- if .Values.fluentd.output.loki.staticLabels }}
         staticLabels: {{ .Values.fluentd.output.loki.staticLabels | squote }}
@@ -521,7 +504,20 @@ spec:
     {{- if  .Values.fluentd.output.http }}
       http:
       {{- if .Values.fluentd.output.http.enabled }}
-        {{- toYaml .Values.fluentd.output.http | nindent 8 }}
+        {{- $http := deepCopy .Values.fluentd.output.http }}
+        {{- if and $http.auth $http.auth.credentials }}
+          {{- $defaultSecretName := include "logging.output.auth.secretName" (dict "auth" $http.auth "default" (printf "%s-fluentd-http-auth" .Release.Name)) }}
+          {{- if not (or (and $http.auth.token $http.auth.token.name) (and $http.auth.user $http.auth.user.name $http.auth.password $http.auth.password.name)) }}
+            {{- if $http.auth.credentials.token }}
+              {{- $_ := set $http.auth "token" (dict "name" $defaultSecretName "key" "token") }}
+            {{- else if and $http.auth.credentials.username $http.auth.credentials.password }}
+              {{- $_ := set $http.auth "user" (dict "name" $defaultSecretName "key" "username") }}
+              {{- $_ := set $http.auth "password" (dict "name" $defaultSecretName "key" "password") }}
+            {{- end }}
+          {{- end }}
+          {{- $_ := set $http "auth" (omit $http.auth "credentials") }}
+        {{- end }}
+        {{- toYaml $http | nindent 8 }}
       {{- else }}
         enabled: false
       {{- end }}
@@ -682,24 +678,7 @@ spec:
         tenant: {{ .Values.fluentbit.output.loki.tenant }}
         {{- end }}
         {{- if .Values.fluentbit.output.loki.auth }}
-        {{- if .Values.fluentbit.output.loki.auth.token }}
-        {{- if and .Values.fluentbit.output.loki.auth.token.name .Values.fluentbit.output.loki.auth.token.key }}
-        auth:
-          token:
-            name: {{ .Values.fluentbit.output.loki.auth.token.name }}
-            key: {{ .Values.fluentbit.output.loki.auth.token.key }}
-        {{- end }}
-        {{- else if and .Values.fluentbit.output.loki.auth.user .Values.fluentbit.output.loki.auth.password }}
-        {{- if and .Values.fluentbit.output.loki.auth.user.name .Values.fluentbit.output.loki.auth.user.key .Values.fluentbit.output.loki.auth.password.name .Values.fluentbit.output.loki.auth.password.key }}
-        auth:
-          user:
-            name: {{ .Values.fluentbit.output.loki.auth.user.name }}
-            key: {{ .Values.fluentbit.output.loki.auth.user.key }}
-          password:
-            name: {{ .Values.fluentbit.output.loki.auth.password.name }}
-            key: {{ .Values.fluentbit.output.loki.auth.password.key }}
-        {{- end }}
-        {{- end }}
+        {{- include "logging.output.auth" (dict "auth" .Values.fluentbit.output.loki.auth "default" (printf "%s-fluentbit-loki-auth" .Release.Name)) | nindent 8 }}
         {{- end }}
         {{- if .Values.fluentbit.output.loki.staticLabels }}
         staticLabels: {{ .Values.fluentbit.output.loki.staticLabels }}
@@ -742,7 +721,20 @@ spec:
     {{- if  .Values.fluentbit.output.http }}
       http:
       {{- if .Values.fluentbit.output.http.enabled }}
-        {{- toYaml .Values.fluentbit.output.http | nindent 8 }}
+        {{- $http := deepCopy .Values.fluentbit.output.http }}
+        {{- if and $http.auth $http.auth.credentials }}
+          {{- $defaultSecretName := include "logging.output.auth.secretName" (dict "auth" $http.auth "default" (printf "%s-fluentbit-http-auth" .Release.Name)) }}
+          {{- if not (or (and $http.auth.token $http.auth.token.name) (and $http.auth.user $http.auth.user.name $http.auth.password $http.auth.password.name)) }}
+            {{- if $http.auth.credentials.token }}
+              {{- $_ := set $http.auth "token" (dict "name" $defaultSecretName "key" "token") }}
+            {{- else if and $http.auth.credentials.username $http.auth.credentials.password }}
+              {{- $_ := set $http.auth "user" (dict "name" $defaultSecretName "key" "username") }}
+              {{- $_ := set $http.auth "password" (dict "name" $defaultSecretName "key" "password") }}
+            {{- end }}
+          {{- end }}
+          {{- $_ := set $http "auth" (omit $http.auth "credentials") }}
+        {{- end }}
+        {{- toYaml $http | nindent 8 }}
       {{- else }}
         enabled: false
       {{- end }}
@@ -750,7 +742,20 @@ spec:
     {{- if  .Values.fluentbit.output.otel }}
       otel:
       {{- if .Values.fluentbit.output.otel.enabled }}
-        {{- toYaml .Values.fluentbit.output.otel | nindent 8 }}
+        {{- $otel := deepCopy .Values.fluentbit.output.otel }}
+        {{- if and $otel.auth $otel.auth.credentials }}
+          {{- $defaultSecretName := include "logging.output.auth.secretName" (dict "auth" $otel.auth "default" (printf "%s-fluentbit-otel-auth" .Release.Name)) }}
+          {{- if not (or (and $otel.auth.token $otel.auth.token.name) (and $otel.auth.user $otel.auth.user.name $otel.auth.password $otel.auth.password.name)) }}
+            {{- if $otel.auth.credentials.token }}
+              {{- $_ := set $otel.auth "token" (dict "name" $defaultSecretName "key" "token") }}
+            {{- else if and $otel.auth.credentials.username $otel.auth.credentials.password }}
+              {{- $_ := set $otel.auth "user" (dict "name" $defaultSecretName "key" "username") }}
+              {{- $_ := set $otel.auth "password" (dict "name" $defaultSecretName "key" "password") }}
+            {{- end }}
+          {{- end }}
+          {{- $_ := set $otel "auth" (omit $otel.auth "credentials") }}
+        {{- end }}
+        {{- toYaml $otel | nindent 8 }}
       {{- else }}
         enabled: false
       {{- end }}
@@ -888,24 +893,7 @@ spec:
           tenant: {{ .Values.fluentbit.aggregator.output.loki.tenant }}
           {{- end }}
           {{- if .Values.fluentbit.aggregator.output.loki.auth }}
-          {{- if .Values.fluentbit.aggregator.output.loki.auth.token }}
-          {{- if and .Values.fluentbit.aggregator.output.loki.auth.token.name .Values.fluentbit.aggregator.output.loki.auth.token.key }}
-          auth:
-            token:
-              name: {{ .Values.fluentbit.aggregator.output.loki.auth.token.name }}
-              key: {{ .Values.fluentbit.aggregator.output.loki.auth.token.key }}
-          {{- end }}
-          {{- else if and .Values.fluentbit.aggregator.output.loki.auth.user .Values.fluentbit.aggregator.output.loki.auth.password }}
-          {{- if and .Values.fluentbit.aggregator.output.loki.auth.user.name .Values.fluentbit.aggregator.output.loki.auth.user.key .Values.fluentbit.aggregator.output.loki.auth.password.name .Values.fluentbit.aggregator.output.loki.auth.password.key }}
-          auth:
-            user:
-              name: {{ .Values.fluentbit.aggregator.output.loki.auth.user.name }}
-              key: {{ .Values.fluentbit.aggregator.output.loki.auth.user.key }}
-            password:
-              name: {{ .Values.fluentbit.aggregator.output.loki.auth.password.name }}
-              key: {{ .Values.fluentbit.aggregator.output.loki.auth.password.key }}
-          {{- end }}
-          {{- end }}
+          {{- include "logging.output.auth" (dict "auth" .Values.fluentbit.aggregator.output.loki.auth "default" (printf "%s-fluentbit-aggregator-loki-auth" .Release.Name)) | nindent 10 }}
           {{- end }}
           {{- if .Values.fluentbit.aggregator.output.loki.staticLabels }}
           staticLabels: {{ .Values.fluentbit.aggregator.output.loki.staticLabels }}
@@ -948,7 +936,20 @@ spec:
       {{- if .Values.fluentbit.aggregator.output.http }}
         http:
         {{- if .Values.fluentbit.aggregator.output.http.enabled }}
-          {{- toYaml .Values.fluentbit.aggregator.output.http | nindent 10 }}
+          {{- $http := deepCopy .Values.fluentbit.aggregator.output.http }}
+          {{- if and $http.auth $http.auth.credentials }}
+            {{- $defaultSecretName := include "logging.output.auth.secretName" (dict "auth" $http.auth "default" (printf "%s-fluentbit-aggregator-http-auth" .Release.Name)) }}
+            {{- if not (or (and $http.auth.token $http.auth.token.name) (and $http.auth.user $http.auth.user.name $http.auth.password $http.auth.password.name)) }}
+              {{- if $http.auth.credentials.token }}
+                {{- $_ := set $http.auth "token" (dict "name" $defaultSecretName "key" "token") }}
+              {{- else if and $http.auth.credentials.username $http.auth.credentials.password }}
+                {{- $_ := set $http.auth "user" (dict "name" $defaultSecretName "key" "username") }}
+                {{- $_ := set $http.auth "password" (dict "name" $defaultSecretName "key" "password") }}
+              {{- end }}
+            {{- end }}
+            {{- $_ := set $http "auth" (omit $http.auth "credentials") }}
+          {{- end }}
+          {{- toYaml $http | nindent 10 }}
         {{- else }}
           enabled: false
         {{- end }}
@@ -956,7 +957,20 @@ spec:
       {{- if .Values.fluentbit.aggregator.output.otel }}
         otel:
         {{- if .Values.fluentbit.aggregator.output.otel.enabled }}
-          {{- toYaml .Values.fluentbit.aggregator.output.otel | nindent 10 }}
+          {{- $otel := deepCopy .Values.fluentbit.aggregator.output.otel }}
+          {{- if and $otel.auth $otel.auth.credentials }}
+            {{- $defaultSecretName := include "logging.output.auth.secretName" (dict "auth" $otel.auth "default" (printf "%s-fluentbit-aggregator-otel-auth" .Release.Name)) }}
+            {{- if not (or (and $otel.auth.token $otel.auth.token.name) (and $otel.auth.user $otel.auth.user.name $otel.auth.password $otel.auth.password.name)) }}
+              {{- if $otel.auth.credentials.token }}
+                {{- $_ := set $otel.auth "token" (dict "name" $defaultSecretName "key" "token") }}
+              {{- else if and $otel.auth.credentials.username $otel.auth.credentials.password }}
+                {{- $_ := set $otel.auth "user" (dict "name" $defaultSecretName "key" "username") }}
+                {{- $_ := set $otel.auth "password" (dict "name" $defaultSecretName "key" "password") }}
+              {{- end }}
+            {{- end }}
+            {{- $_ := set $otel "auth" (omit $otel.auth "credentials") }}
+          {{- end }}
+          {{- toYaml $otel | nindent 10 }}
         {{- else }}
           enabled: false
         {{- end }}

--- a/charts/qubership-logging-operator/templates/output-auth-secrets.yaml
+++ b/charts/qubership-logging-operator/templates/output-auth-secrets.yaml
@@ -1,0 +1,65 @@
+{{- $ctx := . -}}
+
+{{- $authPaths := list }}
+
+{{- if and .Values.fluentd.install .Values.fluentd.output }}
+  {{- if and .Values.fluentd.output.loki .Values.fluentd.output.loki.enabled .Values.fluentd.output.loki.auth }}
+    {{- $authPaths = append $authPaths (dict "auth" .Values.fluentd.output.loki.auth "default" (printf "%s-fluentd-loki-auth" .Release.Name) "component" "fluentd" "output" "loki") }}
+  {{- end }}
+  {{- if and .Values.fluentd.output.http .Values.fluentd.output.http.enabled .Values.fluentd.output.http.auth }}
+    {{- $authPaths = append $authPaths (dict "auth" .Values.fluentd.output.http.auth "default" (printf "%s-fluentd-http-auth" .Release.Name) "component" "fluentd" "output" "http") }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.fluentbit.install }}
+  {{- if and .Values.fluentbit.output .Values.fluentbit.output.loki }}
+    {{- if and .Values.fluentbit.output.loki.enabled .Values.fluentbit.output.loki.auth }}
+      {{- $authPaths = append $authPaths (dict "auth" .Values.fluentbit.output.loki.auth "default" (printf "%s-fluentbit-loki-auth" .Release.Name) "component" "fluentbit" "output" "loki") }}
+    {{- end }}
+  {{- end }}
+  {{- if and .Values.fluentbit.output .Values.fluentbit.output.http }}
+    {{- if and .Values.fluentbit.output.http.enabled .Values.fluentbit.output.http.auth }}
+      {{- $authPaths = append $authPaths (dict "auth" .Values.fluentbit.output.http.auth "default" (printf "%s-fluentbit-http-auth" .Release.Name) "component" "fluentbit" "output" "http") }}
+    {{- end }}
+  {{- end }}
+  {{- if and .Values.fluentbit.output .Values.fluentbit.output.otel }}
+    {{- if and .Values.fluentbit.output.otel.enabled .Values.fluentbit.output.otel.auth }}
+      {{- $authPaths = append $authPaths (dict "auth" .Values.fluentbit.output.otel.auth "default" (printf "%s-fluentbit-otel-auth" .Release.Name) "component" "fluentbit" "output" "otel") }}
+    {{- end }}
+  {{- end }}
+  {{- if and .Values.fluentbit.aggregator .Values.fluentbit.aggregator.install .Values.fluentbit.aggregator.output }}
+    {{- if and .Values.fluentbit.aggregator.output.loki .Values.fluentbit.aggregator.output.loki.enabled .Values.fluentbit.aggregator.output.loki.auth }}
+      {{- $authPaths = append $authPaths (dict "auth" .Values.fluentbit.aggregator.output.loki.auth "default" (printf "%s-fluentbit-aggregator-loki-auth" .Release.Name) "component" "fluentbit-aggregator" "output" "loki") }}
+    {{- end }}
+    {{- if and .Values.fluentbit.aggregator.output.http .Values.fluentbit.aggregator.output.http.enabled .Values.fluentbit.aggregator.output.http.auth }}
+      {{- $authPaths = append $authPaths (dict "auth" .Values.fluentbit.aggregator.output.http.auth "default" (printf "%s-fluentbit-aggregator-http-auth" .Release.Name) "component" "fluentbit-aggregator" "output" "http") }}
+    {{- end }}
+    {{- if and .Values.fluentbit.aggregator.output.otel .Values.fluentbit.aggregator.output.otel.enabled .Values.fluentbit.aggregator.output.otel.auth }}
+      {{- $authPaths = append $authPaths (dict "auth" .Values.fluentbit.aggregator.output.otel.auth "default" (printf "%s-fluentbit-aggregator-otel-auth" .Release.Name) "component" "fluentbit-aggregator" "output" "otel") }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- range $path := $authPaths }}
+  {{- if (include "logging.output.auth.shouldCreateSecret" $path) }}
+    {{- $secretName := include "logging.output.auth.secretName" $path }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "logging.labels" (dict "ctx" $ctx "name" $secretName "component" $path.component) | nindent 4 }}
+type: Opaque
+data:
+    {{- if $path.auth.credentials.username }}
+  username: {{ $path.auth.credentials.username | b64enc }}
+    {{- end }}
+    {{- if $path.auth.credentials.password }}
+  password: {{ $path.auth.credentials.password | b64enc }}
+    {{- end }}
+    {{- if $path.auth.credentials.token }}
+  token: {{ $path.auth.credentials.token | b64enc }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/qubership-logging-operator/values.schema.json
+++ b/charts/qubership-logging-operator/values.schema.json
@@ -1,10 +1,16 @@
 {
     "$defs": {
         "integerOrString": {
-            "type": ["integer", "string"]
+            "type": [
+                "integer",
+                "string"
+            ]
         },
         "optionalString": {
-            "type": ["string", "null"]
+            "type": [
+                "string",
+                "null"
+            ]
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -22,20 +28,28 @@
             "properties": {
                 "affinity": {
                     "description": "Pod's scheduling constraints.",
-                    "examples": [{
+                    "examples": [
+                        {
                             "podAntiAffinity": {
-                                "requiredDuringSchedulingIgnoredDuringExecution": [{
+                                "requiredDuringSchedulingIgnoredDuringExecution": [
+                                    {
                                         "labelSelector": {
-                                            "matchExpressions": [{
+                                            "matchExpressions": [
+                                                {
                                                     "key": "app",
                                                     "operator": "In",
-                                                    "values": ["nginx"]
-                                                }]
+                                                    "values": [
+                                                        "nginx"
+                                                    ]
+                                                }
+                                            ]
                                         },
                                         "topologyKey": "kubernetes.io/hostname"
-                                    }]
+                                    }
+                                ]
                             }
-                        }],
+                        }
+                    ],
                     "type": "object"
                 },
                 "annotations": {
@@ -80,11 +94,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -95,11 +118,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Initial amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -113,7 +145,9 @@
         },
         "cloudURL": {
             "description": "Cloud address. Openshift cloud may require to set the current host address.",
-            "examples": ["https://kubernetes.default.svc"],
+            "examples": [
+                "https://kubernetes.default.svc"
+            ],
             "type": "string"
         },
         "containerRuntimeType": {
@@ -157,11 +191,20 @@
                                                 "cpu": {
                                                     "$ref": "#/$defs/integerOrString",
                                                     "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                                    "examples": ["1", "500m"]
+                                                    "examples": [
+                                                        "1",
+                                                        "500m"
+                                                    ]
                                                 },
                                                 "memory": {
                                                     "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                                    "examples": [
+                                                        "128974848",
+                                                        "129e6",
+                                                        "129M",
+                                                        "128974848000m",
+                                                        "123Mi"
+                                                    ],
                                                     "type": "string"
                                                 }
                                             },
@@ -172,11 +215,20 @@
                                                 "cpu": {
                                                     "$ref": "#/$defs/integerOrString",
                                                     "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                                    "examples": ["1", "500m"]
+                                                    "examples": [
+                                                        "1",
+                                                        "500m"
+                                                    ]
                                                 },
                                                 "memory": {
                                                     "description": "Initial amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                                    "examples": [
+                                                        "128974848",
+                                                        "129e6",
+                                                        "129M",
+                                                        "128974848000m",
+                                                        "123Mi"
+                                                    ],
                                                     "type": "string"
                                                 }
                                             },
@@ -194,9 +246,11 @@
                         },
                         "customLuaScriptConf": {
                             "description": "FluentBit custom lua script configuration. Note: it's very important to keep the indents.",
-                            "examples": [{
+                            "examples": [
+                                {
                                     "scriptname.lua": "\n      <script_content>"
-                                }],
+                                }
+                            ],
                             "type": "object"
                         },
                         "customOutputConf": {
@@ -250,12 +304,16 @@
                         },
                         "nodeSelectorKey": {
                             "description": "Defines a list of nodes the pods are scheduled on. Used with nodeSelectorValue.",
-                            "examples": ["region"],
+                            "examples": [
+                                "region"
+                            ],
                             "type": "string"
                         },
                         "nodeSelectorValue": {
                             "description": "Defines a list of nodes the pods are scheduled on. Used with nodeSelectorKey.",
-                            "examples": ["primary"],
+                            "examples": [
+                                "primary"
+                            ],
                             "type": "string"
                         },
                         "output": {
@@ -317,6 +375,28 @@
                                                         }
                                                     },
                                                     "type": "object"
+                                                },
+                                                "credentials": {
+                                                    "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                                    "properties": {
+                                                        "username": {
+                                                            "description": "Username for basic authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "password": {
+                                                            "description": "Password for basic authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "token": {
+                                                            "description": "Bearer token for token-based authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "secretName": {
+                                                            "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object"
                                                 }
                                             },
                                             "type": "object"
@@ -324,7 +404,12 @@
                                         "compress": {
                                             "default": "gzip",
                                             "description": "Payload compression mechanism for Http output. Allowed values: gzip, snappy, zstd.",
-                                            "enum": ["gzip", "snappy", "zstd", ""],
+                                            "enum": [
+                                                "gzip",
+                                                "snappy",
+                                                "zstd",
+                                                ""
+                                            ],
                                             "type": "string"
                                         },
                                         "enabled": {
@@ -334,17 +419,24 @@
                                         },
                                         "extraParams": {
                                             "description": "Additional configuration parameters for Http output. Bearer token can be set here as well. See docs: https://docs.fluentbit.io/manual/data-pipeline/outputs/http#configuration-parameters",
-                                            "examples": ["|\n  workers  2\n  header  AccountID  100"],
+                                            "examples": [
+                                                "|\n  workers  2\n  header  AccountID  100"
+                                            ],
                                             "type": "string"
                                         },
                                         "host": {
                                             "description": "Http host.",
-                                            "examples": ["vlsingle-k8s.victorialogs", "victorialogs.example.com"],
+                                            "examples": [
+                                                "vlsingle-k8s.victorialogs",
+                                                "victorialogs.example.com"
+                                            ],
                                             "type": "string"
                                         },
                                         "port": {
                                             "description": "Http port",
-                                            "examples": ["9428"],
+                                            "examples": [
+                                                "9428"
+                                            ],
                                             "type": "integer"
                                         },
                                         "tls": {
@@ -462,6 +554,28 @@
                                                         }
                                                     },
                                                     "type": "object"
+                                                },
+                                                "credentials": {
+                                                    "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                                    "properties": {
+                                                        "username": {
+                                                            "description": "Username for basic authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "password": {
+                                                            "description": "Password for basic authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "token": {
+                                                            "description": "Bearer token for token-based authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "secretName": {
+                                                            "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object"
                                                 }
                                             },
                                             "type": "object"
@@ -473,23 +587,32 @@
                                         },
                                         "extraParams": {
                                             "description": "Additional configuration parameters for Loki output. See docs: https://docs.fluentbit.io/manual/pipeline/outputs/loki#configuration-parameters",
-                                            "examples": ["|\n            workers                2\n            Retry_Limit            32\n            storage.total_limit_size  5000M\n            net.connect_timeout 20"],
+                                            "examples": [
+                                                "|\n            workers                2\n            Retry_Limit            32\n            storage.total_limit_size  5000M\n            net.connect_timeout 20"
+                                            ],
                                             "type": "string"
                                         },
                                         "host": {
                                             "description": "Loki host.",
-                                            "examples": ["loki-write.loki.svc", "10.10.10.10"],
+                                            "examples": [
+                                                "loki-write.loki.svc",
+                                                "10.10.10.10"
+                                            ],
                                             "type": "string"
                                         },
                                         "labelsMapping": {
                                             "description": "Labels mappings that defines how to extract labels from each log record. Value should contain a JSON object.",
-                                            "examples": ["|-\n          {\n              \"container\": \"container\",\n              \"pod\": \"pod\",\n              \"namespace\": \"namespace\",\n              \"stream\": \"stream\",\n              \"level\": \"level\",\n              \"hostname\": \"hostname\",\n              \"nodename\": \"nodename\",\n              \"request_id\": \"request_id\",\n              \"tenant_id\": \"tenant_id\",\n              \"addressTo\": \"addressTo\",\n              \"originating_bi_id\": \"originating_bi_id\",\n              \"spanId\": \"spanId\"\n          }"],
+                                            "examples": [
+                                                "|-\n          {\n              \"container\": \"container\",\n              \"pod\": \"pod\",\n              \"namespace\": \"namespace\",\n              \"stream\": \"stream\",\n              \"level\": \"level\",\n              \"hostname\": \"hostname\",\n              \"nodename\": \"nodename\",\n              \"request_id\": \"request_id\",\n              \"tenant_id\": \"tenant_id\",\n              \"addressTo\": \"addressTo\",\n              \"originating_bi_id\": \"originating_bi_id\",\n              \"spanId\": \"spanId\"\n          }"
+                                            ],
                                             "type": "string"
                                         },
                                         "staticLabels": {
                                             "default": "job=fluentbit",
                                             "description": "Static labels that added as stream labels.",
-                                            "examples": ["job=fluentbit"],
+                                            "examples": [
+                                                "job=fluentbit"
+                                            ],
                                             "type": "string"
                                         },
                                         "tenant": {
@@ -608,6 +731,28 @@
                                                         }
                                                     },
                                                     "type": "object"
+                                                },
+                                                "credentials": {
+                                                    "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                                    "properties": {
+                                                        "username": {
+                                                            "description": "Username for basic authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "password": {
+                                                            "description": "Password for basic authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "token": {
+                                                            "description": "Bearer token for token-based authentication",
+                                                            "type": "string"
+                                                        },
+                                                        "secretName": {
+                                                            "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object"
                                                 }
                                             },
                                             "type": "object"
@@ -628,7 +773,10 @@
                                         },
                                         "host": {
                                             "description": "Otel host.",
-                                            "examples": ["10.10.10.10.", "vlsingle-k8s.victorialogs"],
+                                            "examples": [
+                                                "10.10.10.10.",
+                                                "vlsingle-k8s.victorialogs"
+                                            ],
                                             "type": "string"
                                         },
                                         "logSuppressInterval": {
@@ -733,11 +881,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -748,11 +905,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Initial amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -867,16 +1033,22 @@
                         },
                         "tolerations": {
                             "description": "List of tolerations applied to FluentBit aggregator Pods.",
-                            "examples": [[{
+                            "examples": [
+                                [
+                                    {
                                         "key": "node-role.kubernetes.io/master",
                                         "operator": "Exists"
-                                    }, {
+                                    },
+                                    {
                                         "effect": "NoExecute",
                                         "operator": "Exists"
-                                    }, {
+                                    },
+                                    {
                                         "effect": "NoSchedule",
                                         "operator": "Exists"
-                                    }]],
+                                    }
+                                ]
+                            ],
                             "items": {
                                 "type": "object"
                             },
@@ -928,11 +1100,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -943,11 +1124,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Initial amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -1098,6 +1288,28 @@
                                                 }
                                             },
                                             "type": "object"
+                                        },
+                                        "credentials": {
+                                            "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                            "properties": {
+                                                "username": {
+                                                    "description": "Username for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "description": "Password for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "token": {
+                                                    "description": "Bearer token for token-based authentication",
+                                                    "type": "string"
+                                                },
+                                                "secretName": {
+                                                    "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
                                         }
                                     },
                                     "type": "object"
@@ -1105,7 +1317,12 @@
                                 "compress": {
                                     "default": "gzip",
                                     "description": "Payload compression mechanism for Http output. Allowed values: gzip, snappy, zstd.",
-                                    "enum": ["gzip", "snappy", "zstd", ""],
+                                    "enum": [
+                                        "gzip",
+                                        "snappy",
+                                        "zstd",
+                                        ""
+                                    ],
                                     "type": "string"
                                 },
                                 "enabled": {
@@ -1115,17 +1332,24 @@
                                 },
                                 "extraParams": {
                                     "description": "Additional configuration parameters for Http output. Bearer token can be set here as well. See docs: https://docs.fluentbit.io/manual/data-pipeline/outputs/http#configuration-parameters",
-                                    "examples": ["|\n  workers  2\n  header  AccountID  100"],
+                                    "examples": [
+                                        "|\n  workers  2\n  header  AccountID  100"
+                                    ],
                                     "type": "string"
                                 },
                                 "host": {
                                     "description": "Http host.",
-                                    "examples": ["vlsingle-k8s.victorialogs", "victorialogs.example.com"],
+                                    "examples": [
+                                        "vlsingle-k8s.victorialogs",
+                                        "victorialogs.example.com"
+                                    ],
                                     "type": "string"
                                 },
                                 "port": {
                                     "description": "Http port",
-                                    "examples": ["9428"],
+                                    "examples": [
+                                        "9428"
+                                    ],
                                     "type": "integer"
                                 },
                                 "tls": {
@@ -1243,6 +1467,28 @@
                                                 }
                                             },
                                             "type": "object"
+                                        },
+                                        "credentials": {
+                                            "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                            "properties": {
+                                                "username": {
+                                                    "description": "Username for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "description": "Password for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "token": {
+                                                    "description": "Bearer token for token-based authentication",
+                                                    "type": "string"
+                                                },
+                                                "secretName": {
+                                                    "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
                                         }
                                     },
                                     "type": "object"
@@ -1254,23 +1500,32 @@
                                 },
                                 "extraParams": {
                                     "description": "Additional configuration parameters for Loki output. See docs: https://docs.fluentbit.io/manual/pipeline/outputs/loki#configuration-parameters",
-                                    "examples": ["|\n            workers                2\n            Retry_Limit            32\n            storage.total_limit_size  5000M\n            net.connect_timeout 20"],
+                                    "examples": [
+                                        "|\n            workers                2\n            Retry_Limit            32\n            storage.total_limit_size  5000M\n            net.connect_timeout 20"
+                                    ],
                                     "type": "string"
                                 },
                                 "host": {
                                     "description": "Loki host.",
-                                    "examples": ["loki-write.loki.svc", "10.10.10.10"],
+                                    "examples": [
+                                        "loki-write.loki.svc",
+                                        "10.10.10.10"
+                                    ],
                                     "type": "string"
                                 },
                                 "labelsMapping": {
                                     "description": "Labels mappings that defines how to extract labels from each log record. Value should contain a JSON object.",
-                                    "examples": ["|-\n          {\n              \"container\": \"container\",\n              \"pod\": \"pod\",\n              \"namespace\": \"namespace\",\n              \"stream\": \"stream\",\n              \"level\": \"level\",\n              \"hostname\": \"hostname\",\n              \"nodename\": \"nodename\",\n              \"request_id\": \"request_id\",\n              \"tenant_id\": \"tenant_id\",\n              \"addressTo\": \"addressTo\",\n              \"originating_bi_id\": \"originating_bi_id\",\n              \"spanId\": \"spanId\"\n          }"],
+                                    "examples": [
+                                        "|-\n          {\n              \"container\": \"container\",\n              \"pod\": \"pod\",\n              \"namespace\": \"namespace\",\n              \"stream\": \"stream\",\n              \"level\": \"level\",\n              \"hostname\": \"hostname\",\n              \"nodename\": \"nodename\",\n              \"request_id\": \"request_id\",\n              \"tenant_id\": \"tenant_id\",\n              \"addressTo\": \"addressTo\",\n              \"originating_bi_id\": \"originating_bi_id\",\n              \"spanId\": \"spanId\"\n          }"
+                                    ],
                                     "type": "string"
                                 },
                                 "staticLabels": {
                                     "default": "job=fluentbit",
                                     "description": "Static labels that added as stream labels.",
-                                    "examples": ["job=fluentbit"],
+                                    "examples": [
+                                        "job=fluentbit"
+                                    ],
                                     "type": "string"
                                 },
                                 "tenant": {
@@ -1389,6 +1644,28 @@
                                                 }
                                             },
                                             "type": "object"
+                                        },
+                                        "credentials": {
+                                            "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                            "properties": {
+                                                "username": {
+                                                    "description": "Username for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "description": "Password for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "token": {
+                                                    "description": "Bearer token for token-based authentication",
+                                                    "type": "string"
+                                                },
+                                                "secretName": {
+                                                    "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
                                         }
                                     },
                                     "type": "object"
@@ -1409,7 +1686,10 @@
                                 },
                                 "host": {
                                     "description": "Otel host.",
-                                    "examples": ["10.10.10.10", "vlsingle-k8s.victorialogs"],
+                                    "examples": [
+                                        "10.10.10.10",
+                                        "vlsingle-k8s.victorialogs"
+                                    ],
                                     "type": "string"
                                 },
                                 "logSuppressInterval": {
@@ -1625,7 +1905,7 @@
                                     "type": "boolean"
                                 },
                                 "renewBefore": {
-                                    "description": "Defines how long before the certificate’s expiry cert-manager should attempt to renew it.",
+                                    "description": "Defines how long before the certificate\u2019s expiry cert-manager should attempt to renew it.",
                                     "type": "integer"
                                 },
                                 "secretName": {
@@ -1719,11 +1999,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -1734,11 +2023,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Initial amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -1773,7 +2071,11 @@
                 },
                 "excludePath": {
                     "description": "Path to exclude logs, it can have multiple values as an array.",
-                    "examples": [["/var/log/pods/openshift-dns_dns-default*/dns/*.log"]],
+                    "examples": [
+                        [
+                            "/var/log/pods/openshift-dns_dns-default*/dns/*.log"
+                        ]
+                    ],
                     "items": {
                         "type": "string"
                     },
@@ -1781,10 +2083,12 @@
                 },
                 "extraFields": {
                     "description": "Adds additional custom fields/labels to every log message by using filter based on record_transformer plugin. This parameter will override existing fields if their keys match those specified in extraFields. This filter works after all other filters except the custom filter.",
-                    "examples": [{
+                    "examples": [
+                        {
                             "bar_key": "bar_value",
                             "foo_key": "foo_value"
-                        }],
+                        }
+                    ],
                     "type": "object"
                 },
                 "fileStorage": {
@@ -1835,12 +2139,16 @@
                 },
                 "nodeSelectorKey": {
                     "description": "Defines which nodes the pods are scheduled on. Used with nodeSelectorValue",
-                    "examples": ["region"],
+                    "examples": [
+                        "region"
+                    ],
                     "type": "string"
                 },
                 "nodeSelectorValue": {
                     "description": "Defines which nodes the pods are scheduled on. Used with nodeSelectorKey",
-                    "examples": ["primary"],
+                    "examples": [
+                        "primary"
+                    ],
                     "type": "string"
                 },
                 "output": {
@@ -1906,6 +2214,28 @@
                                                 }
                                             },
                                             "type": "object"
+                                        },
+                                        "credentials": {
+                                            "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                            "properties": {
+                                                "username": {
+                                                    "description": "Username for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "description": "Password for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "token": {
+                                                    "description": "Bearer token for token-based authentication",
+                                                    "type": "string"
+                                                },
+                                                "secretName": {
+                                                    "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
                                         }
                                     },
                                     "type": "object"
@@ -1930,7 +2260,10 @@
                                 },
                                 "host": {
                                     "description": "HTTP host URL for ingesting logs.",
-                                    "examples": ["http://10.10.10.10:9428", "https://vlsingle-k8s.victorialogs:9428"],
+                                    "examples": [
+                                        "http://10.10.10.10:9428",
+                                        "https://vlsingle-k8s.victorialogs:9428"
+                                    ],
                                     "type": "string"
                                 },
                                 "path": {
@@ -2053,6 +2386,28 @@
                                                 }
                                             },
                                             "type": "object"
+                                        },
+                                        "credentials": {
+                                            "description": "Inline credentials for authentication. Chart creates a Kubernetes Secret automatically.",
+                                            "properties": {
+                                                "username": {
+                                                    "description": "Username for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "description": "Password for basic authentication",
+                                                    "type": "string"
+                                                },
+                                                "token": {
+                                                    "description": "Bearer token for token-based authentication",
+                                                    "type": "string"
+                                                },
+                                                "secretName": {
+                                                    "description": "Optional name for the auto-created Secret. If not specified, a default name is generated.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
                                         }
                                     },
                                     "type": "object"
@@ -2068,12 +2423,17 @@
                                 },
                                 "host": {
                                     "description": "Loki host URL.",
-                                    "examples": ["http://10.10.10.10:3100", "http://loki-write.loki.svc:3100"],
+                                    "examples": [
+                                        "http://10.10.10.10:3100",
+                                        "http://loki-write.loki.svc:3100"
+                                    ],
                                     "type": "string"
                                 },
                                 "labelsMapping": {
                                     "description": "Labels mappings that defines how to extract labels from each log record",
-                                    "examples": ["|-\n        stream $.stream\n        container $.container\n        pod $.pod\n        namespace $.namespace\n        level $.level\n        hostname $.hostname\n        nodename $.kubernetes_host\n        request_id $.request_id\n        tenant_id $.tenant_id\n        addressTo $.addressTo\n        originating_bi_id $.originating_bi_id\n        spanId $.spanId"],
+                                    "examples": [
+                                        "|-\n        stream $.stream\n        container $.container\n        pod $.pod\n        namespace $.namespace\n        level $.level\n        hostname $.hostname\n        nodename $.kubernetes_host\n        request_id $.request_id\n        tenant_id $.tenant_id\n        addressTo $.addressTo\n        originating_bi_id $.originating_bi_id\n        spanId $.spanId"
+                                    ],
                                     "type": "string"
                                 },
                                 "staticLabels": {
@@ -2083,7 +2443,9 @@
                                 },
                                 "tenant": {
                                     "description": "Loki tenant ID.",
-                                    "examples": ["fake"],
+                                    "examples": [
+                                        "fake"
+                                    ],
                                     "type": "string"
                                 },
                                 "tls": {
@@ -2187,11 +2549,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -2202,11 +2573,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Initial amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -2309,7 +2689,7 @@
                                     "type": "boolean"
                                 },
                                 "renewBefore": {
-                                    "description": "Defines how long before the certificate’s expiry cert-manager should attempt to renew it.",
+                                    "description": "Defines how long before the certificate\u2019s expiry cert-manager should attempt to renew it.",
                                     "type": "integer"
                                 },
                                 "secretName": {
@@ -2629,11 +3009,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -2644,11 +3033,20 @@
                                         "cpu": {
                                             "$ref": "#/$defs/integerOrString",
                                             "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                            "examples": ["1", "500m"]
+                                            "examples": [
+                                                "1",
+                                                "500m"
+                                            ]
                                         },
                                         "memory": {
                                             "description": "Initial and guaranteed amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                            "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                            "examples": [
+                                                "128974848",
+                                                "129e6",
+                                                "129M",
+                                                "128974848000m",
+                                                "123Mi"
+                                            ],
                                             "type": "string"
                                         }
                                     },
@@ -2688,7 +3086,9 @@
                 },
                 "contentPack": {
                     "description": "Graylog content packs.",
-                    "examples": [[{
+                    "examples": [
+                        [
+                            {
                                 "http": {
                                     "credentials": {
                                         "password": {
@@ -2717,7 +3117,9 @@
                                     },
                                     "url": "<graylog content pack path>"
                                 }
-                            }]],
+                            }
+                        ]
+                    ],
                     "items": {
                         "type": "object"
                     },
@@ -2763,11 +3165,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -2778,11 +3189,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Initial and guaranteed amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -2797,7 +3217,9 @@
                 },
                 "host": {
                     "description": "The Graylog host for ingress.",
-                    "examples": ["https://graylog-service.kubernetes.cloud.org/"],
+                    "examples": [
+                        "https://graylog-service.kubernetes.cloud.org/"
+                    ],
                     "type": "string"
                 },
                 "indexReplicas": {
@@ -2826,11 +3248,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -2841,11 +3272,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Initial and guaranteed amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -2895,11 +3335,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -2910,11 +3359,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Initial and guaranteed amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -3206,7 +3664,7 @@
                                             "type": "boolean"
                                         },
                                         "renewBefore": {
-                                            "description": "Defines how long before the certificate’s expiry cert-manager should attempt to renew it.",
+                                            "description": "Defines how long before the certificate\u2019s expiry cert-manager should attempt to renew it.",
                                             "type": "integer"
                                         },
                                         "secretName": {
@@ -3273,7 +3731,7 @@
                                             "type": "boolean"
                                         },
                                         "renewBefore": {
-                                            "description": "Defines how long before the certificate’s expiry cert-manager should attempt to renew it.",
+                                            "description": "Defines how long before the certificate\u2019s expiry cert-manager should attempt to renew it.",
                                             "type": "integer"
                                         },
                                         "secretName": {
@@ -3327,17 +3785,26 @@
                 },
                 "graylogHost": {
                     "description": "Graylog host.",
-                    "examples": ["10.10.10.10", "graylog-service.graylog.svc"],
+                    "examples": [
+                        "10.10.10.10",
+                        "graylog-service.graylog.svc"
+                    ],
                     "type": "string"
                 },
                 "graylogPort": {
                     "description": "Graylog port",
-                    "examples": ["80", "443"],
+                    "examples": [
+                        "80",
+                        "443"
+                    ],
                     "type": "integer"
                 },
                 "graylogProtocol": {
                     "description": "Graylog protocol.",
-                    "examples": ["http", "https"],
+                    "examples": [
+                        "http",
+                        "https"
+                    ],
                     "type": "string"
                 },
                 "image": {
@@ -3360,11 +3827,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Maximum amount of CPU resource that can be used by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Maximum amount of memory that can be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -3375,11 +3851,20 @@
                                 "cpu": {
                                     "$ref": "#/$defs/integerOrString",
                                     "description": "Initial and guaranteed amount of CPU resource that will be reserved by a container's process during 1 scheduling period (100ms). Can be integer cores or millicores.",
-                                    "examples": ["1", "500m"]
+                                    "examples": [
+                                        "1",
+                                        "500m"
+                                    ]
                                 },
                                 "memory": {
                                     "description": "Initial amount of memory that will be allocated to a container's process. Can be expressed as a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, k. Also the power-of-two equivalents are available: Ei, Pi, Ti, Gi, Mi, Ki.",
-                                    "examples": ["128974848", "129e6", "129M", "128974848000m", "123Mi"],
+                                    "examples": [
+                                        "128974848",
+                                        "129e6",
+                                        "129M",
+                                        "128974848000m",
+                                        "123Mi"
+                                    ],
                                     "type": "string"
                                 }
                             },
@@ -3483,7 +3968,9 @@
                         },
                         "url": {
                             "description": "The parameter specifies the url for VictoriaLogs.",
-                            "examples": ["https://vlsingle-example.victorialogs:9428"],
+                            "examples": [
+                                "https://vlsingle-example.victorialogs:9428"
+                            ],
                             "type": "string"
                         }
                     },
@@ -3502,9 +3989,11 @@
         },
         "labels": {
             "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/user-guide/labels",
-            "examples": [{
+            "examples": [
+                {
                     "field": "value"
-                }],
+                }
+            ],
             "type": "object"
         },
         "logLevel": {

--- a/charts/qubership-logging-operator/values.yaml
+++ b/charts/qubership-logging-operator/values.yaml
@@ -890,7 +890,15 @@ fluentd:
       # tenant:
 
       # -- Authentication for Loki.
+      # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+      # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+      # If both are specified, secret references take priority.
       auth: {}
+        # credentials:
+        #   username: ""
+        #   password: ""
+        #   token: ""
+        #   secretName: ""
         # token:
         #   name: loki-secret
         #   key: token
@@ -979,8 +987,15 @@ fluentd:
       # path: /insert/jsonline
 
       # -- Authentication for HTTP output.
-      # Secret name and key in the secret storing the parameter should be provided. Username/password or token can be stored in different secrets.
+      # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+      # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+      # If both are specified, secret references take priority.
       auth: {}
+        # credentials:
+        #   username: ""
+        #   password: ""
+        #   token: ""
+        #   secretName: ""
         # token:
         #   name: vl-write-token
         #   key: token
@@ -1283,7 +1298,15 @@ fluentbit:
       # tenant:
 
       # -- Authentication for Loki.
+      # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+      # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+      # If both are specified, secret references take priority.
       auth: {}
+        # credentials:
+        #   username: ""
+        #   password: ""
+        #   token: ""
+        #   secretName: ""
         # token:
         #   name: loki-secret
         #   key: token
@@ -1371,7 +1394,15 @@ fluentbit:
       # extraParams: |
 
       # -- Authentication for Http.
+      # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+      # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+      # If both are specified, secret references take priority.
       auth: {}
+        # credentials:
+        #   username: ""
+        #   password: ""
+        #   token: ""
+        #   secretName: ""
         # user:
         #   name: http-secret
         #   key: user
@@ -1448,8 +1479,15 @@ fluentbit:
       # extraParams: |
 
       # -- Authentication for Otel.
-      # Secret name and key in the secret storing the parameter should be provided. Username/password or token can be stored in different secrets.
+      # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+      # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+      # If both are specified, secret references take priority.
       auth: {}
+        # credentials:
+        #   username: ""
+        #   password: ""
+        #   token: ""
+        #   secretName: ""
         # user:
         #   name: otel-secret
         #   key: user
@@ -1673,7 +1711,15 @@ fluentbit:
         # host: loki-write.loki.svc
 
         # -- Authentication for Loki.
+        # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+        # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+        # If both are specified, secret references take priority.
         auth: {}
+          # credentials:
+          #   username: ""
+          #   password: ""
+          #   token: ""
+          #   secretName: ""
           # token:
           #   name: loki-secret
           #   key: token
@@ -1757,9 +1803,15 @@ fluentbit:
         # compress: gzip
 
         # -- Authentication for Http.
-        # Secret name and key in the secret storing the parameter should be provided. Username/password or token can be stored in different secrets.
-        #
+        # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+        # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+        # If both are specified, secret references take priority.
         auth: {}
+          # credentials:
+          #   username: ""
+          #   password: ""
+          #   token: ""
+          #   secretName: ""
           # user:
           #   name: http-secret
           #   key: user
@@ -1841,8 +1893,15 @@ fluentbit:
         # extraParams: |
 
         # -- Authentication for Otel.
-        # Secret name and key in the secret storing the parameter should be provided. Username/password or token can be stored in different secrets.
+        # Inline credentials can be specified via `credentials` (chart creates the Secret automatically).
+        # Alternatively, reference pre-created secrets via `token`, `user`, `password`.
+        # If both are specified, secret references take priority.
         auth: {}
+          # credentials:
+          #   username: ""
+          #   password: ""
+          #   token: ""
+          #   secretName: ""
           # user:
           #   name: otel-secret
           #   key: user

--- a/docs/examples/fluentbit/fluentbit-http-output-inline-creds-values.yaml
+++ b/docs/examples/fluentbit/fluentbit-http-output-inline-creds-values.yaml
@@ -1,0 +1,22 @@
+# This is a YAML-formatted file.
+# All parameters specify only as example
+
+fluentbit:
+  install: true
+
+  graylogOutput: false
+
+  output:
+    http:
+      enabled: true
+      host: 1.2.3.4
+      compress: gzip
+      auth:
+        # This is a inline credentials for HTTP output
+        # The Helm chart will automatically save them in a secret and reference it in the logging operator configuration
+        credentials:
+          username: username
+          password: password
+
+fluentd:
+  install: false

--- a/docs/examples/fluentbit/fluentbit-http-output-ref-creds-values.yaml
+++ b/docs/examples/fluentbit/fluentbit-http-output-ref-creds-values.yaml
@@ -1,0 +1,34 @@
+# This is a YAML-formatted file.
+# All parameters specify only as example
+
+fluentbit:
+  install: true
+
+  graylogOutput: false
+
+  output:
+    http:
+      enabled: true
+      host: 1.2.3.4
+      compress: gzip
+      auth:
+        user:
+          key: username
+          name: vl-write-user
+        password:
+          key: password
+          name: vl-write-user
+
+fluentd:
+  install: false
+
+---
+# This Kubernetes should be created before deploy logging operator and FluentBit
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vl-write-user
+type: Opaque
+stringData:
+  username: username
+  password: password

--- a/docs/examples/fluentbit/fluentbit-simple-http-output-values.yaml
+++ b/docs/examples/fluentbit/fluentbit-simple-http-output-values.yaml
@@ -1,0 +1,16 @@
+# This is a YAML-formatted file.
+# All parameters specify only as example
+
+fluentbit:
+  install: true
+
+  graylogOutput: false
+
+  output:
+    http:
+      enabled: true
+      host: 1.2.3.4
+      compress: gzip
+
+fluentd:
+  install: false

--- a/docs/examples/fluentd/fluentd-http-output-inline-creds-values.yaml
+++ b/docs/examples/fluentd/fluentd-http-output-inline-creds-values.yaml
@@ -1,0 +1,19 @@
+# This is a YAML-formatted file.
+# All parameters specify only as example
+
+fluentd:
+  install: true
+
+  graylogOutput: false
+
+  output:
+    http:
+      enabled: true
+      host: 1.2.3.4
+      compress: gzip
+      auth:
+        # This is a inline credentials for HTTP output
+        # The Helm chart will automatically save them in a secret and reference it in the logging operator configuration
+        credentials:
+          username: username
+          password: password

--- a/docs/examples/fluentd/fluentd-http-output-ref-creds-values.yaml
+++ b/docs/examples/fluentd/fluentd-http-output-ref-creds-values.yaml
@@ -1,0 +1,31 @@
+# This is a YAML-formatted file.
+# All parameters specify only as example
+
+fluentd:
+  install: true
+
+  graylogOutput: false
+
+  output:
+    http:
+      enabled: true
+      host: 1.2.3.4
+      compress: gzip
+      auth:
+        user:
+          key: username
+          name: vl-write-user
+        password:
+          key: password
+          name: vl-write-user
+
+---
+# This Kubernetes should be created before deploy logging operator and FluentBit
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vl-write-user
+type: Opaque
+stringData:
+  username: username
+  password: password

--- a/docs/examples/fluentd/fluentd-simple-http-output-values.yaml
+++ b/docs/examples/fluentd/fluentd-simple-http-output-values.yaml
@@ -1,0 +1,13 @@
+# This is a YAML-formatted file.
+# All parameters specify only as example
+
+fluentd:
+  install: true
+
+  graylogOutput: false
+
+  output:
+    http:
+      enabled: true
+      host: 1.2.3.4
+      compress: gzip


### PR DESCRIPTION
# What does this PR do?

In previous PRs, the ability to specify outputs for Loki, HTTP, and OTEL was added. In case of using these outputs with authentication, the user needs to specify references to Kubernetes Secrets, for example:

```yaml
fluentbit:
  output:
    http:
      auth:
        user:
          key: username
          name: vl-write-user
        password:
          key: password
          name: vl-write-user
```

It means that one or several Kubernetes Secrets must be pre-created (manually or using another automation) before deploying logging in Kubernetes.

But we have a requirement to avoid manual steps to deploy our applications in Kubernetes.

## Solution

Add logic in the Helm chart that allows specifying credentials or a token inline, and this data will automatically save in a Kubernetes Secret, reference to which will automatically be added in the LoggingService CR.

How it looks for the user:

```yaml
fluentbit:
  output:
    http:
      auth:
        credentials:
          username: username
          password: password
```

Under the hook, Helm char:

- will create a Kubernetes Secret with `username` and `password` fields
- add in LoggingService CR reference on it, like:

```yaml
  fluentbit:
    output:
      http:
        auth:
          password:
            key: password
            name: <chart_name>-fluentbit-http-auth
          user:
            key: username
            name: <chart_name>-fluentbit-http-auth
```

## How was it tested?

Deployed in Kubernetes with parameters:

```yaml
fluentbit:
  output:
    http:
      auth:
        credentials:
          username: <username>
          password: <password>
```

Next, checked that logs are successfully sending to VictoriaLogs.