### PR TITLE
chore: test new go test with sonar workflow

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -4,15 +4,17 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
-permissions:
-  contents: read
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       sonar-project-key: ${{ steps.config.outputs.sonar-project-key }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Resolve sonar project key based on restricted actors
         id: config
         env:
@@ -34,13 +36,14 @@ jobs:
   test:
     needs: prepare
     name: Build and test with coverage
-    uses: Netcracker/qubership-core-infra/.github/workflows/generic-go-build.yaml@8668020927f2a84d8d096a359c719c3c3a403520 # v2.5.0
+    uses: netcracker/qubership-core-infra/.github/workflows/generic-go-build.yaml@8668020927f2a84d8d096a359c719c3c3a403520 # v2.5.0
     with:
       go-module-dir: '.'
       sonar-project-key: ${{ needs.prepare.outputs.sonar-project-key }}
       cover-packages: './controllers'
       skip-docker: true
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
# What does this PR do?

changes go-test workflow to the new version supporting monorepos.
