### PR TITLE
fix: add lost alert name for FluentBit alerts

### DIFF
--- a/charts/qubership-logging-operator/templates/fluentbit-daemonset/prometheusrule.yaml
+++ b/charts/qubership-logging-operator/templates/fluentbit-daemonset/prometheusrule.yaml
@@ -18,59 +18,59 @@ spec:
   groups:
   - name: {{ .Release.Namespace }}-{{ .Release.Name }}
     rules:
-    - alert:
+    - alert: FluentBit pod is down
       expr: up{job=~".*fluentbit-all-pods"} == 0
-      for: {{ default "3m" .Values.fluentbit.prometheusRules.alertDelay }}
+      for: {{ .Values.fluentbit.prometheusRules.alertDelay | default "3m" }}
       labels:
         severity: critical
         namespace: {{ .Release.Namespace }}
         service: {{ .Release.Name }}
       annotations:
-        summary: "Fluent Bit pod is down"
-        description: "up metric for fluentbit-all-pods = 0 more than {{ default "3m" .Values.fluentbit.prometheusRules.alertDelay }}."
+        summary: "FluentBit pod is down"
+        description: "up metric for fluentbit-all-pods = 0 more than {{ .Values.fluentbit.prometheusRules.alertDelay | default "3m" }}."
     - alert: Graylog pod not running
       expr: kube_pod_status_phase{pod=~".*graylog.*", phase!="Running"} == 1
-      for: {{ default "3m" .Values.fluentbit.prometheusRules.alertDelay }}
+      for: {{ .Values.fluentbit.prometheusRules.alertDelay | default "3m" }}
       labels:
         severity: critical
         namespace: {{ .Release.Namespace }}
         service: {{ .Release.Name }}
       annotations:
         summary: "Graylog pod is not running"
-        description: "Graylog pod is not in Running state for more than {{ default "3m" .Values.fluentbit.prometheusRules.alertDelay }}."
+        description: "Graylog pod is not in Running state for more than {{ .Values.fluentbit.prometheusRules.alertDelay | default "3m" }}."
     - alert: Fluent bit high parse error rate
       expr: max by(namespace, pod, container) (rate(fluentbit_parse_error_total[5m])) > {{ default 20 .Values.fluentbit.prometheusRules.parseErrorRateThreshold }}
-      for: {{ default "5m" .Values.fluentbit.prometheusRules.alertDelay }}
+      for: {{ .Values.fluentbit.prometheusRules.alertDelay | default "5m" }}
       labels:
         severity: warning
         namespace: {{ .Release.Namespace }}
         service: {{ .Release.Name }}
       annotations:
         summary: "High parse error rate in Fluent Bit"
-        description: "Parse error rate is above {{ default 20 .Values.fluentbit.prometheusRules.parseErrorRateThreshold }} per {{ default "5m" .Values.fluentbit.prometheusRules.alertDelay }} minutes."
+        description: "Parse error rate is above {{ .Values.fluentbit.prometheusRules.parseErrorRateThreshold | default 20 }} per {{ .Values.fluentbit.prometheusRules.alertDelay | default "5m" }} minutes."
     - alert: Fluentbit high drop records rate
       expr: max by(name) (rate(fluentbit_filter_drop_records_total[5m])) > {{ default 100 .Values.fluentbit.prometheusRules.dropRecordsRateThreshold }}
-      for: {{ default "5m" .Values.fluentbit.prometheusRules.alertDelay }}
+      for: {{ .Values.fluentbit.prometheusRules.alertDelay | default "5m" }}
       labels:
         severity: warning
         namespace: {{ .Release.Namespace }}
         service: {{ .Release.Name }}
       annotations:
         summary: "High drop records rate in Fluent Bit"
-        description: "Drop records rate is above {{ default 100 .Values.fluentbit.prometheusRules.dropRecordsRateThreshold }} per {{ default "5m" .Values.fluentbit.prometheusRules.alertDelay }} minutes."
+        description: "Drop records rate is above {{ .Values.fluentbit.prometheusRules.dropRecordsRateThreshold | default 100 }} per {{ .Values.fluentbit.prometheusRules.alertDelay | default "5m" }} minutes."
     - alert: Fluentbit storage overlimit
       expr: increase(fluentbit_input_storage_overlimit[5m]) > 0
-      for: {{ default "1m" .Values.fluentbit.prometheusRules.alertDelay }}
+      for: {{ .Values.fluentbit.prometheusRules.alertDelay | default "1m" }}
       labels:
         severity: warning
         namespace: {{ .Release.Namespace }}
         service: {{ .Release.Name }}
       annotations:
         summary: "Fluent Bit storage overlimit"
-        description: "Fluent Bit storage overlimit events detected in the last {{ default "1m" .Values.fluentbit.prometheusRules.alertDelay }}."
+        description: "Fluent Bit storage overlimit events detected in the last {{ .Values.fluentbit.prometheusRules.alertDelay | default "1m" }}."
     - alert: Fluentbit output retries
       expr: rate(fluentbit_output_retries_total[3m]) > 0
-      for: {{ default "1m" .Values.fluentbit.prometheusRules.alertDelay }}
+      for: {{ .Values.fluentbit.prometheusRules.alertDelay | default "1m" }}
       labels:
         severity: warning
         namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
# What does this PR do?

The logging-operator deploy process via ArgoCD failed with the sync error:

```bash
PrometheusRule.monitoring.coreos.com "prometheus-fluentbit-alerts" is invalid: spec.groups[0].rules[0].alert: Invalid value: "null": spec.groups[0].rules[0].alert in body must be of type string: "null"
```

## Solution

 Add lost alert name for FluentBit alerts

Additional changes:
- Move defaults in filters
