### PR TITLE
fix: copy detected_level after levels are normalized

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Install required CRDs
       run: |
-        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
-        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
-        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
-        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
-        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Install required CRDs
       run: |
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.88.0/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Install required CRDs
       run: |
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/0.81.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Install required CRDs
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
+        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
+        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
+        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl replace -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-nonsupported-levels.conf
+++ b/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-nonsupported-levels.conf
@@ -3,3 +3,9 @@
     Match             *
     script            /fluent-bit/etc/update_level_syslog.lua
     call              update_level
+
+# Copy level to detected_level for logql to logsql converter
+[FILTER]
+    Name                modify
+    Match               *
+    Copy                level       detected_level

--- a/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-post-generic.conf
+++ b/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-post-generic.conf
@@ -93,9 +93,3 @@
     Remove_key          log
     Remove_key          original_log
     Remove_Key          logfmt_candidate
-
-# Copy level to detected_level for logql to logsql converter
-[FILTER]
-    Name                modify
-    Match               *
-    Copy                level       detected_level

--- a/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-nonsupported-levels.conf
+++ b/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-nonsupported-levels.conf
@@ -3,3 +3,9 @@
     Match        *
     script       /fluent-bit/etc/update_level_syslog.lua
     call         update_level
+
+# Copy level to detected_level for logql to logsql converter
+[FILTER]
+    Name                modify
+    Match               *
+    Copy                level       detected_level

--- a/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-post-generic.conf
+++ b/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-post-generic.conf
@@ -94,12 +94,6 @@
     Remove_key          original_log
     Remove_Key          logfmt_candidate
 
-# Copy level to detected_level for logql to logsql converter
-[FILTER]
-    Name                modify
-    Match               *
-    Copy                level       detected_level
-
 # Add mandatory fields for gelf format to all records
 [FILTER]
     Name                record_modifier


### PR DESCRIPTION
# What does this PR do?

Corrects the place where `detected_level` is copied from already normalized `level` field.
