### PR TITLE
fix: normalize detected_level to match grafana levels

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -126,8 +126,8 @@ jobs:
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Install required CRDs
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Install required CRDs
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -127,7 +127,7 @@ jobs:
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
         kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Install required CRDs
       run: |
-        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml
         kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl apply --server-side -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/tags/v0.88.0/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_alertmanagerconfigs.yaml
     - name: Checkout OpenSearch repo
       if: matrix.backend == 'graylog'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-post-generic.conf
+++ b/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/filters/filter-post-generic.conf
@@ -93,9 +93,3 @@
     Remove_key          log
     Remove_key          original_log
     Remove_Key          logfmt_candidate
-
-# Copy level to detected_level for logql to logsql converter
-[FILTER]
-    Name                modify
-    Match               *
-    Copy                level       detected_level

--- a/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/lua_scripts/update_level_syslog.lua
+++ b/controllers/fluentbit-forwarder-aggregator/aggregator.configmap/conf.d/lua_scripts/update_level_syslog.lua
@@ -5,48 +5,73 @@
 -- this script marks non supported levels with syslog codes
 -- input: https://docs.fluentbit.io/manual/pipeline/filters/lua#function-arguments
 -- output: https://docs.fluentbit.io/manual/pipeline/filters/lua#return-values
-function update_level(tag, timestamp, record)
-  record["source_level"] = record["level"]
-  if (record["level"] ~= nil) then
-    record["level"] = string.lower(record["level"]):gsub("^%s*(.-)%s*$", "%1")
-    local first_ch = string.sub(record["level"], 1, 1)
-    -- p = panic
-    if first_ch == '0' or first_ch == 'p' then
-      record["level"] = "emerg"
-    -- a = alert, f = fatal, s = severe
-    elseif first_ch == '1' or first_ch == 'a' or first_ch == 'f' or first_ch == 's' then
-      record["level"] = "alert"
-    -- c = crit
-    elseif first_ch == '2' or first_ch == 'c' then
-      record["level"] = "crit"
-    elseif first_ch == '3' then
-      record["level"] = "err"
-    -- w = warning
-    elseif first_ch == '4' or first_ch == 'w' then
-      record["level"] = "warning"
-    -- n = notice
-    elseif first_ch == '5' or first_ch == 'n' then
-      record["level"] = "notice"
-    -- i = info
-    elseif first_ch == '6' or first_ch == 'i' then
-      record["level"] = "info"
-    -- d = debug, t = trace, v = verbose
-    elseif first_ch == '7' or first_ch == 'd' or first_ch == 't' or first_ch == 'v' then
-      record["level"] = "debug"
-    -- e, er = err, e(~=r) = emerg
-    elseif first_ch == 'e' then
-      if string.len(record["level"]) >=2 and string.sub(record["level"], 2, 2) ~= 'r' then
-        record["level"] = "emerg"
-      else
-        record["level"] = "err"
-      end
+local function normalize_levels(level)
+  local normalized = "info"
+  local detected = "info"
+
+  if level == nil then
+    return normalized, detected, true
+  end
+
+  level = string.lower(level):gsub("^%s*(.-)%s*$", "%1")
+  local first_ch = string.sub(level, 1, 1)
+
+  -- p = panic
+  if first_ch == '0' or first_ch == 'p' then
+    normalized = "emerg"
+    detected = "critical"
+  -- a = alert, f = fatal, s = severe
+  elseif first_ch == '1' or first_ch == 'a' or first_ch == 'f' or first_ch == 's' then
+    normalized = "alert"
+    detected = "critical"
+  -- c = crit
+  elseif first_ch == '2' or first_ch == 'c' then
+    normalized = "crit"
+    detected = "critical"
+  elseif first_ch == '3' then
+    normalized = "err"
+    detected = "error"
+  -- w = warning
+  elseif first_ch == '4' or first_ch == 'w' then
+    normalized = "warning"
+    detected = "warn"
+  -- n = notice
+  elseif first_ch == '5' or first_ch == 'n' then
+    normalized = "notice"
+    detected = "info"
+  -- i = info
+  elseif first_ch == '6' or first_ch == 'i' then
+    normalized = "info"
+    detected = "info"
+  -- d = debug, v = verbose
+  elseif first_ch == '7' or first_ch == 'd' or first_ch == 'v' then
+    normalized = "debug"
+    detected = "debug"
+  elseif first_ch == 't' then
+    normalized = "debug"
+    detected = "trace"
+  -- e, er = err, e(~=r) = emerg
+  elseif first_ch == 'e' then
+    if string.len(level) >=2 and string.sub(level, 2, 2) ~= 'r' then
+      normalized = "emerg"
+      detected = "critical"
     else
-      record["parse_level_unknown"] = "true"
-      record["level"] = "info"
+      normalized = "err"
+      detected = "error"
     end
   else
+    return "info", "info", true
+  end
+
+  return normalized, detected, false
+end
+
+function update_level(tag, timestamp, record)
+  record["source_level"] = record["level"]
+  local level_unknown
+  record["level"], record["detected_level"], level_unknown = normalize_levels(record["level"])
+  if level_unknown then
     record["parse_level_unknown"] = "true"
-    record["level"] = "info"
   end
 
   -- return 2, that means the original timestamp is not modified and the record has been modified

--- a/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-post-generic.conf
+++ b/controllers/fluentbit/fluentbit.configmap/conf.d/filters/filter-post-generic.conf
@@ -94,12 +94,6 @@
     Remove_key          original_log
     Remove_Key          logfmt_candidate
 
-# Copy level to detected_level for logql to logsql converter
-[FILTER]
-    Name                modify
-    Match               *
-    Copy                level       detected_level
-
 # Add mandatory fields for gelf format to all records
 [FILTER]
     Name                record_modifier

--- a/controllers/fluentbit/fluentbit.configmap/conf.d/lua_scripts/update_level_syslog.lua
+++ b/controllers/fluentbit/fluentbit.configmap/conf.d/lua_scripts/update_level_syslog.lua
@@ -5,48 +5,73 @@
 -- this script marks non supported levels with syslog codes
 -- input: https://docs.fluentbit.io/manual/pipeline/filters/lua#function-arguments
 -- output: https://docs.fluentbit.io/manual/pipeline/filters/lua#return-values
-function update_level(tag, timestamp, record)
-  record["source_level"] = record["level"]
-  if (record["level"] ~= nil) then
-    record["level"] = string.lower(record["level"]):gsub("^%s*(.-)%s*$", "%1")
-    local first_ch = string.sub(record["level"], 1, 1)
-    -- p = panic
-    if first_ch == '0' or first_ch == 'p' then
-      record["level"] = "emerg"
-    -- a = alert, f = fatal, s = severe
-    elseif first_ch == '1' or first_ch == 'a' or first_ch == 'f' or first_ch == 's' then
-      record["level"] = "alert"
-    -- c = crit
-    elseif first_ch == '2' or first_ch == 'c' then
-      record["level"] = "crit"
-    elseif first_ch == '3' then
-      record["level"] = "err"
-    -- w = warning
-    elseif first_ch == '4' or first_ch == 'w' then
-      record["level"] = "warning"
-    -- n = notice
-    elseif first_ch == '5' or first_ch == 'n' then
-      record["level"] = "notice"
-    -- i = info
-    elseif first_ch == '6' or first_ch == 'i' then
-      record["level"] = "info"
-    -- d = debug, t = trace, v = verbose
-    elseif first_ch == '7' or first_ch == 'd' or first_ch == 't' or first_ch == 'v' then
-      record["level"] = "debug"
-    -- e, er = err, e(~=r) = emerg
-    elseif first_ch == 'e' then
-      if string.len(record["level"]) >=2 and string.sub(record["level"], 2, 2) ~= 'r' then
-        record["level"] = "emerg"
-      else
-        record["level"] = "err"
-      end
+local function normalize_levels(level)
+  local normalized = "info"
+  local detected = "info"
+
+  if level == nil then
+    return normalized, detected, true
+  end
+
+  level = string.lower(level):gsub("^%s*(.-)%s*$", "%1")
+  local first_ch = string.sub(level, 1, 1)
+
+  -- p = panic
+  if first_ch == '0' or first_ch == 'p' then
+    normalized = "emerg"
+    detected = "critical"
+  -- a = alert, f = fatal, s = severe
+  elseif first_ch == '1' or first_ch == 'a' or first_ch == 'f' or first_ch == 's' then
+    normalized = "alert"
+    detected = "critical"
+  -- c = crit
+  elseif first_ch == '2' or first_ch == 'c' then
+    normalized = "crit"
+    detected = "critical"
+  elseif first_ch == '3' then
+    normalized = "err"
+    detected = "error"
+  -- w = warning
+  elseif first_ch == '4' or first_ch == 'w' then
+    normalized = "warning"
+    detected = "warn"
+  -- n = notice
+  elseif first_ch == '5' or first_ch == 'n' then
+    normalized = "notice"
+    detected = "info"
+  -- i = info
+  elseif first_ch == '6' or first_ch == 'i' then
+    normalized = "info"
+    detected = "info"
+  -- d = debug, v = verbose
+  elseif first_ch == '7' or first_ch == 'd' or first_ch == 'v' then
+    normalized = "debug"
+    detected = "debug"
+  elseif first_ch == 't' then
+    normalized = "debug"
+    detected = "trace"
+  -- e, er = err, e(~=r) = emerg
+  elseif first_ch == 'e' then
+    if string.len(level) >=2 and string.sub(level, 2, 2) ~= 'r' then
+      normalized = "emerg"
+      detected = "critical"
     else
-      record["parse_level_unknown"] = "true"
-      record["level"] = "info"
+      normalized = "err"
+      detected = "error"
     end
   else
+    return "info", "info", true
+  end
+
+  return normalized, detected, false
+end
+
+function update_level(tag, timestamp, record)
+  record["source_level"] = record["level"]
+  local level_unknown
+  record["level"], record["detected_level"], level_unknown = normalize_levels(record["level"])
+  if level_unknown then
     record["parse_level_unknown"] = "true"
-    record["level"] = "info"
   end
 
   -- return 2, that means the original timestamp is not modified and the record has been modified

--- a/docs/fluentbit-log-pipeline.md
+++ b/docs/fluentbit-log-pipeline.md
@@ -125,19 +125,22 @@ identify its format, and detect its severity level.
 If the log structure matches any of the supported log formats,
 the following fields must always be present in the resulting log output:
 
-1) level – The severity level of the log.
+1) level – The GELF/syslog-compatible severity level of the log.
    Must be one of: `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
    If the original severity level cannot be detected, the level is set to info.
-2) parse_status – Indicates whether the log was successfully parsed.
+2) detected_level – The Grafana-friendly severity level derived from the same source value.
+   Possible values: `trace`, `debug`, `info`, `warn`, `error`, `critical`.
+   This field is intended for HTTP-based backends such as VictoriaLogs and for adapters that emulate Loki responses.
+3) parse_status – Indicates whether the log was successfully parsed.
    Possible values: success, failed.
-3) parse_format – The detected original log format.
+4) parse_format – The detected original log format.
    Possible values: `json`, `logfmt`, `klog`, `qubership`, `java`, `opensearch`, and other third-party formats.
-4) log_category – The source type of the log. Possible values: container, audit, system.
-5) parse_level_unknown – Indicates that the original severity level could not be detected
+5) log_category – The source type of the log. Possible values: container, audit, system.
+6) parse_level_unknown – Indicates that the original severity level could not be detected
    or did not match any known severity levels.
-6) namespace – The namespace of the log source. Present only if the log originates from a Kubernetes container.
-7) pod – The pod of the log source. Present only if the log originates from a Kubernetes container.
-8) container – The container of the log source. Present only if the log originates from a Kubernetes container.
-9) nodename – The Kubernetes node where the log source is located.
-10) hostname – The FluentBit pod that processed and sent the log.
-11) labels - The set of labels from the pod originated the log.
+7) namespace – The namespace of the log source. Present only if the log originates from a Kubernetes container.
+8) pod – The pod of the log source. Present only if the log originates from a Kubernetes container.
+9) container – The container of the log source. Present only if the log originates from a Kubernetes container.
+10) nodename – The Kubernetes node where the log source is located.
+11) hostname – The FluentBit pod that processed and sent the log.
+12) labels - The set of labels from the pod originated the log.

--- a/scripts/lua-tests/test-update-level.lua
+++ b/scripts/lua-tests/test-update-level.lua
@@ -76,48 +76,73 @@ local test_strings = {
 -- this script marks non supported levels with syslog codes
 -- input: https://docs.fluentbit.io/manual/pipeline/filters/lua#function-arguments
 -- output: https://docs.fluentbit.io/manual/pipeline/filters/lua#return-values
-function update_level(tag, timestamp, record)
-  record["source_level"] = record["level"]
-  if (record["level"] ~= nil) then
-    record["level"] = string.lower(record["level"]):gsub("^%s*(.-)%s*$", "%1")
-    local first_ch = string.sub(record["level"], 1, 1)
-    -- p = panic
-    if first_ch == '0' or first_ch == 'p' then
-      record["level"] = "emerg"
-    -- a = alert, f = fatal, s = severe
-    elseif first_ch == '1' or first_ch == 'a' or first_ch == 'f' or first_ch == 's' then
-      record["level"] = "alert"
-    -- c = crit
-    elseif first_ch == '2' or first_ch == 'c' then
-      record["level"] = "crit"
-    elseif first_ch == '3' then
-      record["level"] = "err"
-    -- w = warning
-    elseif first_ch == '4' or first_ch == 'w' then
-      record["level"] = "warning"
-    -- n = notice
-    elseif first_ch == '5' or first_ch == 'n' then
-      record["level"] = "notice"
-    -- i = info
-    elseif first_ch == '6' or first_ch == 'i' then
-      record["level"] = "info"
-    -- d = debug, t = trace, v = verbose
-    elseif first_ch == '7' or first_ch == 'd' or first_ch == 't' or first_ch == 'v' then
-      record["level"] = "debug"
-    -- e, er = err, e(~=r) = emerg
-    elseif first_ch == 'e' then
-      if string.len(record["level"]) >=2 and string.sub(record["level"], 2, 2) ~= 'r' then
-        record["level"] = "emerg"
-      else
-        record["level"] = "err"
-      end
+local function normalize_levels(level)
+  local normalized = "info"
+  local detected = "info"
+
+  if level == nil then
+    return normalized, detected, true
+  end
+
+  level = string.lower(level):gsub("^%s*(.-)%s*$", "%1")
+  local first_ch = string.sub(level, 1, 1)
+
+  -- p = panic
+  if first_ch == '0' or first_ch == 'p' then
+    normalized = "emerg"
+    detected = "critical"
+  -- a = alert, f = fatal, s = severe
+  elseif first_ch == '1' or first_ch == 'a' or first_ch == 'f' or first_ch == 's' then
+    normalized = "alert"
+    detected = "critical"
+  -- c = crit
+  elseif first_ch == '2' or first_ch == 'c' then
+    normalized = "crit"
+    detected = "critical"
+  elseif first_ch == '3' then
+    normalized = "err"
+    detected = "error"
+  -- w = warning
+  elseif first_ch == '4' or first_ch == 'w' then
+    normalized = "warning"
+    detected = "warn"
+  -- n = notice
+  elseif first_ch == '5' or first_ch == 'n' then
+    normalized = "notice"
+    detected = "info"
+  -- i = info
+  elseif first_ch == '6' or first_ch == 'i' then
+    normalized = "info"
+    detected = "info"
+  -- d = debug, v = verbose
+  elseif first_ch == '7' or first_ch == 'd' or first_ch == 'v' then
+    normalized = "debug"
+    detected = "debug"
+  elseif first_ch == 't' then
+    normalized = "debug"
+    detected = "trace"
+  -- e, er = err, e(~=r) = emerg
+  elseif first_ch == 'e' then
+    if string.len(level) >=2 and string.sub(level, 2, 2) ~= 'r' then
+      normalized = "emerg"
+      detected = "critical"
     else
-      record["parse_level_unknown"] = "true"
-      record["level"] = "info"
+      normalized = "err"
+      detected = "error"
     end
   else
+    return "info", "info", true
+  end
+
+  return normalized, detected, false
+end
+
+function update_level(tag, timestamp, record)
+  record["source_level"] = record["level"]
+  local level_unknown
+  record["level"], record["detected_level"], level_unknown = normalize_levels(record["level"])
+  if level_unknown then
     record["parse_level_unknown"] = "true"
-    record["level"] = "info"
   end
 
   -- return 2, that means the original timestamp is not modified and the record has been modified
@@ -142,6 +167,7 @@ function execute_real_func_test()
                 print("Complete update_level = ", end_time, "Execution time =", end_time - start_time)
                 print("Code:", code, "Processing order:", time)
                 print("Update level:", test_string, "=>", v)
+                print("Detected level:", test_string, "=>", new_test_structure["detected_level"])
                 print("------------------------------------------------------------------------")
             end
             if (k == "level" and code == 0) then


### PR DESCRIPTION
# What does this PR do?

The `level` field in logs processed by Fluent Bit does not match the log level values expected by Grafana for proper colorization and histogram grouping in the Logs Drilldown view.
The `detected_level` field no longer simply duplicates level - it is now normalized as well, ensuring proper behavior for Grafana Logs Drilldown visualizations.