### PR TITLE
fix: set limits for fluentd filters

### DIFF
--- a/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-k8s-container-detect-exceptions.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-k8s-container-detect-exceptions.conf
@@ -5,4 +5,6 @@
   message log
   force_line_breaks true
   multiline_flush_interval 0.1
+  max_lines 500
+  max_bytes 2097152
 </match>

--- a/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-k8s-container-multiline.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/filters/filter-k8s-container-multiline.conf
@@ -7,4 +7,5 @@
   partial_cri_logtag_key logtag
   partial_cri_stream_key stream
   separator ""
+  flush_interval 5
 </filter>


### PR DESCRIPTION
# What does this PR do?

set limits for fluentd multiline filters due sometimes log records become really huge (larger than buffer chunk limit size) and it can lead to OOM.
