### PR TITLE
chore(deploy): add helmfile-based local kind deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ site/
 
 # Claude Code local settings
 .claude/
+
+# Local deploy env files
+deploy/**/.env

--- a/deploy/kind/.env.example
+++ b/deploy/kind/.env.example
@@ -1,0 +1,24 @@
+# Copy to .env and adjust. .env is gitignored.
+#
+#   cp deploy/kind/.env.example deploy/kind/.env
+
+# Required: kind cluster name. helmfile will target context "kind-${CLUSTER_NAME}"
+# and refuse to run against anything else.
+CLUSTER_NAME=logging
+
+# Required: which backend to install.
+#   graylog       — OpenSearch + Graylog
+#   victorialogs  — VictoriaMetrics operator + VLSingle
+BACKEND=graylog
+
+# PVC storageClass used by OpenSearch / Graylog / VLSingle.
+# Defaults to "standard" if unset.
+STORAGE_CLASS=local-path
+
+# qubership-opensearch chart release (used when BACKEND=graylog).
+# https://github.com/Netcracker/qubership-opensearch/releases
+OPENSEARCH_VERSION=2.3.0
+
+# VictoriaMetrics operator chart version (used when BACKEND=victorialogs).
+# Leave empty to pull latest from the vm helm repo.
+VM_OPERATOR_VERSION=

--- a/deploy/kind/README.md
+++ b/deploy/kind/README.md
@@ -1,0 +1,97 @@
+# Local kind deployment
+
+## Prereqs
+
+```bash
+brew install kind helm helmfile
+helm plugin install https://github.com/databus23/helm-diff --verify=false
+```
+
+## Install
+
+```bash
+cp deploy/kind/.env.example deploy/kind/.env
+# edit deploy/kind/.env — set CLUSTER_NAME and BACKEND (graylog | victorialogs)
+
+kind create cluster --name "$(grep ^CLUSTER_NAME deploy/kind/.env | cut -d= -f2)"
+
+set -a && source deploy/kind/.env && set +a
+helmfile -f deploy/kind/helmfile.yaml.gotmpl apply
+```
+
+> First `apply` with `BACKEND=graylog` pulls a ~1.5GB OpenSearch image — give it 30–40 min on a fresh node.
+
+## Switch backend
+
+```bash
+# tear down current backend, edit BACKEND in deploy/kind/.env, then apply again
+set -a && source deploy/kind/.env && set +a
+helmfile -f deploy/kind/helmfile.yaml.gotmpl destroy
+
+# edit BACKEND, source again, apply
+helmfile -f deploy/kind/helmfile.yaml.gotmpl apply
+```
+
+## Access the UI
+
+Port-forward the backend service to `localhost` while the cluster is running.
+
+**Graylog** (web UI on `:9000`, default creds `admin` / `admin`):
+
+```bash
+kubectl --context "kind-$CLUSTER_NAME" -n logging port-forward svc/graylog-service 9000:9000
+# open http://localhost:9000
+```
+
+**VictoriaLogs** (HTTP API + built-in UI on `:9428`):
+
+```bash
+kubectl --context "kind-$CLUSTER_NAME" -n logging port-forward svc/vlsingle-k8s 9428:9428
+# open http://localhost:9428/select/vmui
+```
+
+## Log generator
+
+The stack always installs `qubership-log-generator` in namespace `log-generator`. It writes all built-in patterns
+(java/go/json/nginx/glusterd/unicode/spring/zipkin) at 5 msg/sec each with multiline enabled; the fluentbit daemonset
+picks the lines up from `/var/log/containers` and ships them to the active backend. To stream the raw output:
+
+```bash
+kubectl --context "kind-$CLUSTER_NAME" -n log-generator logs -f -l name=qubership-log-generator
+```
+
+The chart ships an HTTP server with a UI for sending one-off custom messages into the same stream, plus Prometheus
+metrics. The kind preset has `ingress.enabled: false`, so reach it via port-forward:
+
+```bash
+kubectl --context "kind-$CLUSTER_NAME" -n log-generator port-forward svc/qubership-log-generator-service 8080:8080
+# UI:      http://localhost:8080/customLogEditorPage
+# Metrics: http://localhost:8080/metrics
+```
+
+Chart lives in the sibling repo at `../qubership-log-generator/charts/qubership-log-generator` relative to this repo
+root — clone it next to `qubership-logging-operator`.
+
+## Hooks
+
+- `prepare-node.sh` (prepare) — creates `/var/log/audit` on each kind node and raises `vm.max_map_count`, without which
+  FluentBit crashloops and OpenSearch refuses to start.
+- `apply-monitoring-crds.sh` (prepare) — pre-installs `ServiceMonitor` / `PodMonitor` / `PrometheusRule` /
+  `GrafanaDashboard` / `LoggingService` / `OpenSearchService` CRDs, without which helm render fails on a fresh cluster.
+  The `qubership-monitoring-operator` source URL is **pinned to commit `2c0cf2537b`**: upstream commit `c61cc8e`
+  (2026-05-12) upgraded grafana-operator 4.x→5.x and renamed the GrafanaDashboard group from `integreatly.org` to
+  `grafana.integreatly.org`, but the qubership-logging-operator and qubership-log-generator charts still emit
+  `apiVersion: integreatly.org/v1alpha1`. Until both charts migrate, the pre-rename CRD is what makes helm render
+  succeed. Once the charts migrate, drop the pin and switch the URL back to `refs/heads/main`.
+- `install-vlsingle.sh` (vmo postsync) — applies the `VLSingle` CR after the VictoriaMetrics operator installs its
+  CRD; this CR is what actually spawns the log-storage workload.
+- `uninstall-vlsingle.sh` (vmo preuninstall) — deletes the `VLSingle` CR while the operator is still alive so it can
+  garbage-collect the Deployment / Service / PVC instead of orphaning them.
+
+## Uninstall
+
+```bash
+set -a && source deploy/kind/.env && set +a
+helmfile -f deploy/kind/helmfile.yaml.gotmpl destroy
+kind delete cluster --name "$CLUSTER_NAME"
+```

--- a/deploy/kind/helmfile.yaml.gotmpl
+++ b/deploy/kind/helmfile.yaml.gotmpl
@@ -1,0 +1,113 @@
+# Brings up the full logging stack on a local kind cluster.
+# Backend selection via BACKEND env: "graylog" or "victorialogs".
+#
+# CLUSTER_NAME is required and pins helm to context "kind-${CLUSTER_NAME}" —
+# helmfile will refuse to apply against anything else.
+#
+# Usage:
+#   cp deploy/kind/.env.example deploy/kind/.env   # then edit
+#   set -a && source deploy/kind/.env && set +a
+#   helmfile -f deploy/kind/helmfile.yaml apply
+
+helmDefaults:
+  kubeContext: kind-{{ requiredEnv "CLUSTER_NAME" }}
+
+repositories:
+  - name: vm
+    url: https://victoriametrics.github.io/helm-charts/
+
+hooks:
+  - events: ["prepare"]
+    showlogs: true
+    command: "bash"
+    args: ["-c", "./hooks/prepare-node.sh && ./hooks/apply-monitoring-crds.sh"]
+
+{{- $backend := requiredEnv "BACKEND" }}
+{{- if and (ne $backend "graylog") (ne $backend "victorialogs") }}
+  {{- fail (printf "BACKEND must be 'graylog' or 'victorialogs', got %q" $backend) }}
+{{- end }}
+
+releases:
+  # ── Graylog backend ────────────────────────────────────────────────────────
+  - name: opensearch
+    namespace: opensearch
+    createNamespace: true
+    condition: backend.graylog.enabled
+    chart: https://github.com/Netcracker/qubership-opensearch/releases/download/{{ env "OPENSEARCH_VERSION" | default "2.3.0" }}/opensearch-{{ env "OPENSEARCH_VERSION" | default "2.3.0" }}.tgz
+    values:
+      - values-opensearch.yaml
+      - opensearch:
+          master:
+            persistence:
+              storageClass: {{ env "STORAGE_CLASS" | default "standard" }}
+    wait: true
+    waitForJobs: true
+    timeout: 1800
+
+  # ── VictoriaLogs backend ───────────────────────────────────────────────────
+  - name: vmo
+    namespace: logging
+    createNamespace: true
+    condition: backend.victorialogs.enabled
+    chart: vm/victoria-metrics-operator
+    {{- with env "VM_OPERATOR_VERSION" }}
+    version: {{ . }}
+    {{- end }}
+    wait: true
+    timeout: 600
+    hooks:
+      - events: ["postsync"]
+        showlogs: true
+        command: "bash"
+        args: ["./hooks/install-vlsingle.sh"]
+      - events: ["preuninstall"]
+        showlogs: true
+        command: "bash"
+        args: ["./hooks/uninstall-vlsingle.sh"]
+
+  # ── Logging operator (both backends, values vary) ──────────────────────────
+  - name: qubership-logging-operator
+    namespace: logging
+    createNamespace: true
+    chart: ../../charts/qubership-logging-operator
+    needs:
+      {{- if eq $backend "graylog" }}
+      - opensearch/opensearch
+      {{- else }}
+      - logging/vmo
+      {{- end }}
+    values:
+      - values-logging-{{ $backend }}.yaml
+      {{- if eq $backend "graylog" }}
+      - graylog:
+          mongoStorageClassName: {{ env "STORAGE_CLASS" | default "standard" }}
+          graylogStorageClassName: {{ env "STORAGE_CLASS" | default "standard" }}
+      {{- end }}
+    # The chart's LoggingService CR has no Ready status condition, so helm's
+    # --wait blocks until timeout. Skip it — Deployment/DaemonSet rollouts are
+    # the meaningful readiness signal.
+    wait: false
+    timeout: 1800
+
+  # ── Log generator (required for both backends — produces test traffic) ─────
+  # Writes the full set of preset patterns (java/go/json/nginx/glusterd/unicode
+  # /spring/zipkin) to stdout at 5 msg/sec each with multiline enabled. The
+  # cluster's fluentbit daemonset picks it up from /var/log/containers and
+  # ships it to the active backend.
+  - name: qubership-log-generator
+    namespace: log-generator
+    createNamespace: true
+    chart: ../../../qubership-log-generator/charts/qubership-log-generator
+    needs:
+      - logging/qubership-logging-operator
+    values:
+      - values-log-generator.yaml
+    wait: true
+    timeout: 600
+
+values:
+  - backend:
+      graylog:
+        enabled: {{ eq $backend "graylog" }}
+      victorialogs:
+        enabled: {{ eq $backend "victorialogs" }}

--- a/deploy/kind/hooks/apply-monitoring-crds.sh
+++ b/deploy/kind/hooks/apply-monitoring-crds.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# qubership-logging-operator chart renders ServiceMonitor / PodMonitor /
+# PrometheusRule / GrafanaDashboard. Without these CRDs helm install fails.
+# Skip any CRD that's already installed — don't overwrite a foreign version.
+# Pinned to the commit before grafana-operator 4.x→5.x (c61cc8e, 2026-05-12),
+# which renamed the GrafanaDashboard group from integreatly.org to
+# grafana.integreatly.org. Charts in this repo (and qubership-log-generator)
+# still reference the old group, so we install the pre-rename CRDs.
+BASE="https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/2c0cf2537b/charts/qubership-monitoring-operator/charts"
+
+apply_if_missing() {
+    local name="$1" url="$2"
+    if kubectl get crd "$name" >/dev/null 2>&1; then
+        echo "✓ $name already installed, skipping"
+    else
+        # Some CRDs are too large for client-side apply (annotation size limit).
+        kubectl apply --server-side -f "$url"
+    fi
+}
+
+apply_if_missing grafanadashboards.integreatly.org \
+    "$BASE/grafana-operator/crds/integreatly.org_grafanadashboards.yaml"
+apply_if_missing prometheusrules.monitoring.coreos.com \
+    "$BASE/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml"
+apply_if_missing servicemonitors.monitoring.coreos.com \
+    "$BASE/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml"
+apply_if_missing podmonitors.monitoring.coreos.com \
+    "$BASE/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml"
+
+# Pre-install CRDs that charts reference from their own templates. On a fresh
+# cluster helmfile's diff render fails because the API isn't registered yet.
+
+# qubership-logging-operator's LoggingService CR is rendered by the chart.
+apply_if_missing loggingservices.logging.netcracker.com \
+    "$(dirname "$0")/../../../charts/qubership-logging-operator/crds/logging.netcracker.com_loggingservices.yaml"
+
+if [[ "${BACKEND:-}" == "graylog" ]]; then
+    OS_VER="${OPENSEARCH_VERSION:-2.3.0}"
+    apply_if_missing opensearchservices.netcracker.com \
+        "https://raw.githubusercontent.com/Netcracker/qubership-opensearch/${OS_VER}/operator/charts/helm/opensearch-service/crds/crd.yaml"
+fi

--- a/deploy/kind/hooks/install-vlsingle.sh
+++ b/deploy/kind/hooks/install-vlsingle.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installed after the VictoriaMetrics operator release. Waits for the operator
+# rollout, applies a VLSingle CR named "k8s", waits for it to become operational.
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required}"
+STORAGE_CLASS="${STORAGE_CLASS:-standard}"
+CTX="kind-${CLUSTER_NAME}"
+
+kubectl --context "$CTX" -n logging rollout status \
+    deployment -l app.kubernetes.io/instance=vmo --timeout=300s
+
+cat <<EOF | kubectl --context "$CTX" apply -f -
+apiVersion: operator.victoriametrics.com/v1
+kind: VLSingle
+metadata:
+    name: k8s
+    namespace: logging
+spec:
+    resources:
+        limits:
+            cpu: 500m
+            memory: 256Mi
+        requests:
+            cpu: 250m
+            memory: 64Mi
+    retentionPeriod: '1'
+    storage:
+        resources:
+            requests:
+                storage: 5Gi
+        storageClassName: ${STORAGE_CLASS}
+EOF
+
+kubectl --context "$CTX" -n logging wait \
+    --for=jsonpath='{.status.updateStatus}'=operational \
+    vlsingle/k8s --timeout=300s

--- a/deploy/kind/hooks/prepare-node.sh
+++ b/deploy/kind/hooks/prepare-node.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Per-node prep before installing OpenSearch + logging stack:
+#   1) /var/log/audit  — FluentBit reads /var/log/audit/audit.log from the host
+#      filesystem on each node it runs on. On a fresh kind node it doesn't
+#      exist, so the input fails and the pod crash-loops.
+#   2) vm.max_map_count >= 262144 — OpenSearch refuses to start otherwise.
+#      In recent kernels (Docker Desktop 4.x uses Linux 6.x) vm.max_map_count
+#      is namespaced and can be raised inside a privileged kind node container.
+# Both steps are idempotent.
+
+REQUIRED_MAX_MAP_COUNT="${REQUIRED_MAX_MAP_COUNT:-262144}"
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required (source deploy/kind/.env first)}"
+
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+    echo "kind cluster '$CLUSTER_NAME' not found." >&2
+    exit 1
+fi
+
+NODES=()
+while IFS= read -r line; do NODES+=("$line"); done < <(kind get nodes --name "$CLUSTER_NAME")
+
+failed_nodes=()
+
+for node in "${NODES[@]}"; do
+    echo "▶ $node"
+
+    docker exec "$node" bash -c \
+        "mkdir -p /var/log/audit && chown 1000:1000 /var/log/audit && ls -ld /var/log/audit"
+
+    current=$(docker exec "$node" sysctl -n vm.max_map_count)
+    if ((current >= REQUIRED_MAX_MAP_COUNT)); then
+        echo "  vm.max_map_count=$current (>= $REQUIRED_MAX_MAP_COUNT) ✓"
+        continue
+    fi
+
+    echo "  vm.max_map_count=$current — raising to $REQUIRED_MAX_MAP_COUNT…"
+    if docker exec "$node" sysctl -w "vm.max_map_count=$REQUIRED_MAX_MAP_COUNT" >/dev/null 2>&1; then
+        new=$(docker exec "$node" sysctl -n vm.max_map_count)
+        if ((new >= REQUIRED_MAX_MAP_COUNT)); then
+            echo "  vm.max_map_count=$new ✓"
+            continue
+        fi
+    fi
+
+    failed_nodes+=("$node")
+done
+
+if ((${#failed_nodes[@]} > 0)); then
+    cat >&2 <<MSG
+
+✗ Could not raise vm.max_map_count on: ${failed_nodes[*]}
+
+    vm.max_map_count is namespaced only on Linux 6.x+. If the kind nodes refuse
+    the sysctl write, the host's Docker Desktop VM kernel is too old or the
+    setting is not yet namespaced. Raise it on the Docker Desktop VM itself:
+
+    docker run --rm --privileged --pid=host alpine \
+        sysctl -w vm.max_map_count=$REQUIRED_MAX_MAP_COUNT
+
+    Then re-run 'helmfile apply'. The setting persists for the lifetime of the
+    Docker Desktop VM (until you 'Restart' it from the UI).
+MSG
+    exit 1
+fi

--- a/deploy/kind/hooks/uninstall-vlsingle.sh
+++ b/deploy/kind/hooks/uninstall-vlsingle.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs before the vmo release is uninstalled. Deletes the VLSingle CR while
+# the VM operator is still around to garbage-collect its Deployment / Service
+# / PVC. Without this the workload pods become orphaned after helmfile destroy.
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required}"
+CTX="kind-${CLUSTER_NAME}"
+
+if ! kubectl --context "$CTX" get vlsingle k8s -n logging >/dev/null 2>&1; then
+    echo "✓ vlsingle/k8s already absent"
+    exit 0
+fi
+
+kubectl --context "$CTX" delete vlsingle k8s -n logging --wait=true --timeout=120s

--- a/deploy/kind/values-log-generator.yaml
+++ b/deploy/kind/values-log-generator.yaml
@@ -1,0 +1,292 @@
+# Self-contained overrides for qubership-log-generator on the kind stack.
+# This file is the single source of truth for the generator's runtime config —
+# the sibling chart's values.yaml is left at its upstream defaults.
+#
+# What this preset does:
+# - Activates ALL built-in pattern families (java/go/json/nginx/glusterd/
+#   unicode/spring/zipkin) under *_low names defined in customConfig below.
+#   Built-in names are deliberately not listed in `templates:` so their
+#   default 1000 msg/sec rates don't fire alongside our slowed-down copies.
+# - 5 msg/sec per template variant. With go (4) and unicode (3) having
+#   multiple sub-variants, total throughput is ~70 msg/sec.
+# - Multiline enabled (probability 0.3) — only java/go-3rd/glusterd/unicode
+#   have multiline blocks, so others produce single lines.
+# - generationTime 3600 s = 1 hour per template, after which the threads exit
+#   (pod stays Running, just stops emitting).
+# - Ingress disabled — kind doesn't ship an ingress controller and the
+#   generator's UI is not needed for ingestion testing.
+
+ingress:
+  enabled: false
+
+# The chart's dashboard.yaml uses the legacy integreatly.org/v1alpha1 API
+# while the cluster ships grafana.integreatly.org. We don't need the
+# dashboard for ingestion testing — disable it to keep helm render happy.
+monitoring:
+  metricsEnabled: true
+  dashboardEnabled: false
+
+multiline:
+  enabled: true
+  probability: 0.3
+
+# Global fallback for any template that doesn't set its own messagesPerSec.
+# All entries below DO set it explicitly, so this is just a safety net.
+messagesPerSec: 5
+generationTime: 3600
+
+templates:
+  - "java_low"
+  - "go_low"
+  - "json_low"
+  - "nginx_low"
+  - "glusterd_low"
+  - "unicode_low"
+  - "springLogo_low"
+  - "zipkinLogo_low"
+
+customConfig:
+  config:
+    # ----- java -----
+    - name: "java_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "yyyy-MM-dd HH:mm:ss,SSS"
+      template: "[${level}] ${package}.${class}: ${explanation};"
+      fields:
+        level: [INFO, WARN, ERROR]
+        package:
+          - com.nc.application.generator
+          - com.nc.application.executor
+          - com.nc.application.provider
+        class:
+          - InterruptedqubershipException
+          - BadException
+          - ArrayIndexOutOfBoundsException
+        explanation:
+          - clean channel shutdown
+          - socket closed
+          - connection refused
+      multiline:
+        - template: "\tat com.example.app.${class}.${method}(${class}.java:${line})"
+          fields:
+            class: [LalaTest, GoodTest, BadTest]
+            method: [getIndex, setValue, isAvailable]
+            line: ["5", "7", "14"]
+        - template: "${method} request ${address}:6300/${path} : SUCCESS"
+          fields:
+            method: [GET, POST]
+            path: [api/leads, api/customers, api/orders]
+            address: ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+
+    # ----- go: 4 sub-variants -----
+    - name: "go_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "[yyyy-MM-dd'T'HH:mm:ss,SSS'Z']"
+      template: "/go/pkg/mod/example.com/${package}:${line}: ${message}"
+      fields:
+        package:
+          - go-logr/zapr@v0.2.0/zapr.go
+          - local-app/lapp@v1.1.0/start.go
+          - qubership-rep/qubership@0.0.1/config.go
+        line: ["32", "5", "19", "57"]
+        message:
+          - Message successfully submitted
+          - Message successfully submitted with warnings
+          - Message successfully submitted to request url
+    - name: "go_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "[yyyy-MM-dd'T'HH:mm:ss,SSS'Z']"
+      template: "[${level}][caller=${class}.go][msg=\"${message}\"]"
+      fields:
+        class: [tls_config, node_exporter, filesystem_common]
+        level: [info, warn]
+        message:
+          - Build context
+          - Parsed flag --collector.filesystem.fs-types-exclude
+          - Enabled collectors
+    - name: "go_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "[yyyy-MM-dd'T'HH:mm:ss,SSS'Z']"
+      template: "${level} ${dashboard} failed to request dashboard url, falling back to config map; if specified {\"error\": \"request failed with status 404\"}"
+      fields:
+        level: [WARN, ERROR]
+        dashboard:
+          - qubership-dashboard
+          - qubership-node-exporter-dashboard
+          - qubership-kube-overview-dashborad
+      multiline:
+        - template: "qubership-repository.com/grafana-operator/grafana-operator/v4/controllers/grafanadashboard.(*${class}).${method}"
+          fields:
+            class: [DashboardPipelineImpl, GrafanaDashboardReconciler, SetupWithManager]
+            method: [obtainJson, ProcessDashboard, reconcileDashboards, Reconcile]
+        - template: "/workspace/controllers/grafanadashboard/${class}.go:${line}"
+          fields:
+            class:
+              - dashboard_pipeline
+              - grafanadashboard_controller
+              - grafana_reconciler
+              - datasource_controller
+            line: ["176", "108", "56", "37"]
+    - name: "go_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "'I'0622 HH:mm:ss,SSSSSS"
+      template: "1 ${class}.go:645] (from=qubership-log-generator) Throttling request took 1.045883302s, request: GET:https://${address}:443/apis/qubership.org/${version}?timeout=32s"
+      fields:
+        class: [warnings, request]
+        address: ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"]
+        version: [v9, v10, v11]
+
+    # ----- json -----
+    - name: "json_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "{\"'lvl'\":\"'INFO'\",\"'ts'\":\"yyyy-MM-dd'T'HH:mm:ss,SSS\""
+      template: ",\"logger\":\"${logger}\",\"msg\":\"${message}\",\"from\":\"qubership-log-generator\"}"
+      fields:
+        logger:
+          - qubership_operator_reconciler
+          - qubership_etcd_monitor_reconciler
+          - qubership_kubernetes_monitors_reconciler
+          - qubership_nodeexporter_reconciler
+        message:
+          - Reconciling component
+          - Reconciliation started
+          - Uninstalling component if exists
+
+    # ----- nginx: 2 sub-variants -----
+    - name: "nginx_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "'I'0622 HH:mm:ss,SSSSSS"
+      template: "8 event.go:282] Event(v1.ObjectReference{Kind:\"Ingress\", Namespace:\"${namespace}\", Name:\"${service}\", UID:\"3b976065-9838-4a7e-912a-c5820a2b7e6a\", APIVersion:\"networking.k8s.io/v1beta1\", ResourceVersion:\"228573236\", FieldPath:\"\"}): type: 'Normal' reason: 'Sync' Scheduled for sync"
+      fields:
+        namespace: [qubership-ns1, qubership-ns2, qubership-ns3, qubership-ns4]
+        service:
+          - qubership-airflow-manager
+          - qubership-ha-test
+          - qubership-prometheus-operator
+    - name: "nginx_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "'W'0622 HH:mm:ss,SSSSSS"
+      template: "8 controller.go:992] Service \"${namespace}/${service}\" does not have any active Endpoint."
+      fields:
+        namespace: [qubership-ns1, qubership-ns2, qubership-ns3, qubership-ns4]
+        service:
+          - qubership-airflow-manager
+          - qubership-ha-test
+          - qubership-prometheus-operator
+          - qubership-opensearch
+
+    # ----- glusterd -----
+    - name: "glusterd_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "[yyyy-MM-dd HH:mm:ss.SSSSSS]"
+      template: " ${letter} ${MSGID} [${source}] ${action}: ${message}"
+      fields:
+        letter: [W, I, E]
+        MSGID:
+          - "[MSGID: 106479]"
+          - "[MSGID: 1062379]"
+          - "[MSGID: 12179]"
+          - ""
+        source:
+          - "socket.c:1600:__socket_rwv"
+          - "rdma.c:4630:__gf_rdma_ctx_create"
+          - "glusterd-store.c:2241:glusterd_restore_op_version"
+          - "event-epoll.c:613:event_dispatch_epoll_worker"
+        action: [0-management, 0-pmap, 0-glusterd, 0-epoll]
+        message:
+          - readv on 10.0.0.1:24007 failed (No data available)
+          - Maximum allowed open file descriptors set to 65536
+          - Starting glustershd service
+          - "Received ACC from uuid: a53c44d1-b573-4d19-a561-c668a3438d38"
+          - "Detected new install. Setting op-version to maximum : 31202"
+          - Using /var/run/gluster as pid file working directory
+      multiline:
+        - template: "Final graph:\n
+            +------------------------------------------------------------------------------+\n
+            \  1: volume management\n
+            \  2:     type mgmt/glusterd\n
+            \  3:     option transport.listen-backlog ${number}\n
+            \  4:     option event-threads ${number}\n
+            \  5:     option ping-timeout ${number}\n
+            \  6: end-volume\n
+            +------------------------------------------------------------------------------+"
+          fields:
+            number: ["2", "10", "34", "1", "0"]
+
+    # ----- unicode: 3 alphabets -----
+    - name: "unicode_low"
+      # Arabic
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "yyyy-MM-dd HH:mm:ss,SSS"
+      symbolRange: { from: 0x0600, to: 0x06FF }
+      wordLength: { from: 5, to: 10 }
+      logLength: { max: 100, min: 20 }
+      multiline:
+        - symbolRange: { from: 0x0600, to: 0x06FF }
+          wordLength: { from: 5, to: 10 }
+          logLength: { max: 100, min: 20 }
+    - name: "unicode_low"
+      # Cyrillic
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "yyyy-MM-dd HH:mm:ss,SSS"
+      symbolRange: { from: 0x0400, to: 0x04FF }
+      wordLength: { from: 5, to: 10 }
+      logLength: { max: 100, min: 20 }
+      multiline:
+        - symbolRange: { from: 0x0400, to: 0x04FF }
+          wordLength: { from: 5, to: 10 }
+          logLength: { max: 100, min: 20 }
+    - name: "unicode_low"
+      # Hiragana
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: "yyyy-MM-dd HH:mm:ss,SSS"
+      symbolRange: { from: 0x3040, to: 0x309F }
+      wordLength: { from: 5, to: 10 }
+      logLength: { max: 100, min: 20 }
+      multiline:
+        - symbolRange: { from: 0x3040, to: 0x309F }
+          wordLength: { from: 5, to: 10 }
+          logLength: { max: 100, min: 20 }
+
+    # ----- ASCII art banners -----
+    - name: "springLogo_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: ""
+      template: "\n\n
+                \ \ .   ____          _            __ _ _\n
+                \ /\\\\ / ___'_ __ _ _(_)_ __  __ _ \\ \\ \\ \\\n
+                ( ( )\\___ | '_ | '_| | '_ \\/ _` | \\ \\ \\ \\\n
+                \ \\\\/  ___)| |_)| | | | | || (_| |  ) ) ) )\n
+                \ \ '  |____| .__|_| |_|_| |_\\__, | / / / /\n
+                \ =========|_|==============|___/=/_/_/_/\n
+                \ :: Spring Boot ::                (v${version})\n"
+      fields:
+        version: [2.7.4, 2.2.8, 6.6.6]
+    - name: "zipkinLogo_low"
+      messagesPerSec: 5
+      generationTime: 3600
+      dateFormat: ""
+      template: "\n\n
+                \     ________ ____  _  _____ _   _\n
+                \    |__  /_ _|  _ \\| |/ /_ _| \\ | |\n
+                \      / / | || |_) | ' / | ||  \\| |\n
+                \     / /_ | ||  __/| . \\ | || |\\  |\n
+                \    |____|___|_|   |_|\\_\\___|_| \\_|\n
+                \n
+                :: version ${version} :: commit ${commit} ::\n\n"
+      fields:
+        version: [2.7.4, 2.2.8, 6.6.6]
+        commit: [24787e213c, 34i32uiuwe, 8wed324iud]

--- a/deploy/kind/values-logging-graylog.yaml
+++ b/deploy/kind/values-logging-graylog.yaml
@@ -1,0 +1,24 @@
+# Aligned with .github/workflows/integration-tests.yml@0c69ffa
+skipMetricsService: false
+containerRuntimeType: containerd
+
+graylog:
+  install: true
+  host: http://graylog.demo.qubership.org
+  initContainerDockerImage: alpine:3.17.2
+  elasticsearchHost: http://admin:admin@opensearch.opensearch:9200
+  indexShards: 1
+  indexReplicas: 0
+
+cloudEventsReader:
+  dockerImage: ghcr.io/netcracker/qubership-kube-events-reader:main
+
+fluentbit:
+  install: true
+  configmapReload:
+    dockerImage: ghcr.io/jimmidyson/configmap-reload:v0.13.1
+  graylogHost: graylog-service
+  graylogPort: 12201
+
+fluentd:
+  install: false

--- a/deploy/kind/values-logging-victorialogs.yaml
+++ b/deploy/kind/values-logging-victorialogs.yaml
@@ -1,0 +1,24 @@
+# Aligned with .github/workflows/integration-tests.yml (victorialogs scenario)
+containerRuntimeType: containerd
+
+cloudEventsReader:
+  install: true
+  dockerImage: ghcr.io/netcracker/qubership-kube-events-reader:main
+
+fluentbit:
+  install: true
+  containerLogging: true
+  graylogOutput: false
+  output:
+    http:
+      enabled: true
+      # vlsingle-<name>.<namespace> — name fixed to "k8s" in manifests/vlsingle.yaml
+      host: vlsingle-k8s.logging
+      port: 9428
+      auth:
+        credentials:
+          username: admin
+          password: admin
+
+fluentd:
+  install: false

--- a/deploy/kind/values-opensearch.yaml
+++ b/deploy/kind/values-opensearch.yaml
@@ -1,0 +1,36 @@
+# Aligned with .github/workflows/integration-tests.yml@0c69ffa
+operator:
+  dockerImage: ghcr.io/netcracker/qubership-opensearch-operator:2.3.0
+
+dashboards:
+  enabled: false
+
+opensearch:
+  master:
+    enabled: true
+    replicas: 1
+    persistence:
+      enabled: true
+  securityConfig:
+    authc:
+      basic:
+        username: "admin"
+        password: "admin"
+  tls:
+    enabled: false
+  config:
+    # Single-node kind: don't freeze indices when host disk fills past 85%.
+    cluster.routing.allocation.disk.threshold_enabled: false
+  dockerImage: ghcr.io/netcracker/qubership-docker-opensearch-2:2.3.0
+  dockerTlsInitImage: ghcr.io/netcracker/qubership-opensearch-tls-init:2.3.0
+
+monitoring:
+  enabled: false
+
+dbaasAdapter:
+  enabled: false
+
+curator:
+  enabled: false
+  username: "admin"
+  password: "admin"


### PR DESCRIPTION
## What

Adds a self-contained [helmfile](https://github.com/helmfile/helmfile)-based workflow for spinning up the full logging stack on a local [kind](https://kind.sigs.k8s.io/) cluster, under `deploy/kind/`. Nothing outside that directory changes except three `.gitignore` entries.

## Why

There was no one-command local environment for trying the operator end to end. This gives contributors a reproducible kind setup with a choice of backend and a built-in log generator, so changes can be exercised against real log flow without a full cluster.

## What's included

- `helmfile.yaml.gotmpl` — drives the whole install, switchable backend via `BACKEND` env var:
  - `graylog` — OpenSearch + Graylog
  - `victorialogs` — VictoriaMetrics operator + VLSingle
- `.env.example` — copy to `.env` (gitignored), set `CLUSTER_NAME`, `BACKEND`, storage class, chart versions.
- Hooks (`deploy/kind/hooks/`) — node prep, monitoring CRDs, VLSingle install/uninstall.
- `qubership-log-generator` always installed in its own namespace; FluentBit ships its output to the active backend.
- `README.md` — prereqs, install, backend switch, UI access, log streaming.

## Testing

Exercised locally on kind with both `BACKEND=graylog` and `BACKEND=victorialogs`: install, backend switch via `destroy` + `apply`, and log flow confirmed through the FluentBit daemonset into each backend.
