### PR TITLE
feat(logging-l1-triage): add L1 triage skill package

### DIFF
--- a/agent-packages/logging-l1-triage/.apm/instructions/logging-l1-triage.instructions.md
+++ b/agent-packages/logging-l1-triage/.apm/instructions/logging-l1-triage.instructions.md
@@ -1,0 +1,23 @@
+---
+description: Triggers for the logging-l1-triage skills — classifying an incoming logging-stack support ticket, then deciding the next action on it.
+applyTo: "**/*"
+---
+
+## Skill trigger: `logging-l1-classification`
+
+When classifying what the author of an incoming Qubership logging-stack support
+ticket is asking for — a problem on a specific installation, a consultation
+about an existing capability, a request for a new feature, or a
+security/vulnerability remediation — apply the `logging-l1-classification`
+skill. It decides from ticket content and emits one intent label plus a uniform
+localization (component / platform / phase / symptom or topic). `unknown` is the
+only "not sure" value. It classifies and localizes only: no system access, no
+answers, no ticket mutation.
+
+## Skill trigger: `logging-l1-outcome`
+
+After a logging-stack ticket has been classified by `logging-l1-classification`,
+apply the `logging-l1-outcome` skill to decide the next action: request missing
+data, flag a suspected known issue with a draft reply, or hand a structured
+packet to L2. It reads ticket content and attachments, takes no system action,
+and never mutates or closes the ticket.

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-classification/SKILL.md
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-classification/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: logging-l1-classification
+description: First-hop classification and localization of incoming Qubership logging-stack support tickets. Use when triaging what a ticket author is asking for (a problem on an installation, a consultation, a feature request, or a security/vulnerability remediation) and where it sits (which component, on VM or Kubernetes, at runtime or during deploy, and the specific symptom or topic). Decides from ticket content; uses the author's Ticket Type only as a tie-breaker and ignores Resolution/Root Cause. Research-phase skill; classifies only, takes no system action and answers nothing.
+---
+
+# logging-l1-classification
+
+## What this does
+
+For one logging-stack support ticket, decide from its **content**: (1) the
+author's **intent**, then (2) a uniform **localization** drilldown. First hop of
+an L1 pipeline; later hops (answering, remediation) are out of scope.
+
+## Hard rules
+
+- **No system access, no answers, no mutation.** Only label.
+- **`unknown` is the only "not sure".** No confidence fields. Prefer `unknown`
+  over a guess (precision over recall). `unknown` on an axis stops the drilldown.
+- Ignore `Resolution` / `Root Cause` — not available at intake.
+
+## Procedure — follow these four steps in order
+
+**Step 1 — attach signals (mechanical).** Write `Summary` + `Description` +
+`Steps to Reproduce` to a temp file and run the bundled extractor (use this
+skill's base directory, shown when it loads):
+
+```bash
+python3 <skill-dir>/scripts/extract_signals.py /tmp/ticket.txt
+```
+
+It prints hits per namespace: `problem` / `consultation` / `feature_request` /
+`security` (intent) and `component` / `platform` / `phase` / `symptom` / `topic`
+(localization). In the research batch these are pre-attached to each record.
+
+**Step 2 — read first, signals later.** Read `Summary` + `Description` + `Steps`
+and form your own one-line read of what the author wants. Do NOT look at the
+signal hits yet.
+
+**Step 3 — reconcile with the signals.** Now compare your read to the hits and
+adjust. Signals are strong evidence, but you weigh them differently per decision
+(see Decision 1 and Decision 2 below).
+
+**Step 4 — tie-break with `ticket_type` (last resort only).** If content plus
+signals still leave it genuinely two-way, use the author's `ticket_type`
+(`Defect` → problem, `Inquiry` → consultation, `Action Item` → neutral). Never
+over a clear content signal.
+
+## Decision 1 — intent
+
+`problem | consultation | feature_request | security | unknown`. Pick by the
+**dominant ask**:
+
+- something is broken / failing / degraded now → `problem`
+- a question — "how to", "is it possible", "where is" → `consultation`
+- asking to add or change a product capability → `feature_request`
+- asking to remediate a CVE / vulnerability / scan finding → `security`
+
+Signal rule (asymmetric — this matters):
+
+- A `consultation` / `feature_request` / `security` signal is **strong**: if one
+  fired, take that intent seriously even if your first read said `problem`. These
+  are the classes a quick read under-detects.
+- A bare `problem` signal is **weak**: failure words ("error", "fail") appear
+  inside questions too, so they do not by themselves make a `problem`. The form
+  of the ask wins — a question is `consultation` even if it cites an error.
+- Still two-way after content + signals → `ticket_type` (Step 4). Otherwise
+  `unknown`.
+
+## Decision 2 — localization (only when `intent != unknown`)
+
+Walk `component → platform → phase → leaf`. **Here signals are a strong prior:**
+if an axis signal fired and the text does not contradict it, use that value — do
+NOT fall back to `unknown`. Use `unknown` only when no signal fired and the text
+gives no clear cue.
+
+- **`component`** — where in the stack: `graylog | fluentd | fluentbit |
+  opensearch | operator | mongodb | events-reader | all | unknown`. The surface
+  the author points at, not a root cause. A Ruby error/stacktrace ⇒ `fluentd`
+  (Fluentd is Ruby; FluentBit is C). `all` = cross-cutting (common for
+  `security`).
+- **`platform`** — where it runs: `vm | kubernetes | unknown`. OpenShift / EKS =
+  `kubernetes`. Forwarders and operator are effectively always `kubernetes`; the
+  backend (graylog / mongodb / opensearch) may be either.
+- **`phase`** — lifecycle: `runtime | deploy | unknown`. `deploy` = install /
+  upgrade / restore (ansible `TASK [...]`, install/upgrade jobs,
+  `external-logging-installer`). `operator` vs `deploy`: `operator` is a
+  *component* (the running controller); `deploy` is a *phase*. They are
+  orthogonal — "operator failed to reconcile during an upgrade" =
+  `component=operator` + `phase=deploy`.
+- **leaf:**
+  - `problem` → **`symptom`** (the chief complaint, a surface not a root cause).
+    Base: `not_running | no_data | performance | disk_space | oom_memory |
+    data_correctness | auth_cert | config_error`. A component-specific symptom
+    (e.g. `graylog.stream_index`, `opensearch.cluster_red_yellow`,
+    `fluentd.buffer_overflow`) only when it matches the chosen `component`. A
+    deploy-specific symptom (e.g. `deploy.prereq_check`, `deploy.image_unavailable`,
+    `deploy.artifact_fetch`, `deploy.task_error`, `deploy.config_validation`) only
+    when `phase == deploy`. Two apply → take the one the author leads with. Else
+    `unknown`.
+  - `consultation` / `feature_request` / `security` → **`topic`**:
+    `output_target | retention | backup_restore | sizing_resources | integration |
+    rbac_auth`, else `unknown`. `security` is usually `component=all`,
+    `topic=unknown`.
+
+## Output
+
+Emit exactly one JSON object per ticket, matching the worklist `uid`, with
+`rationale` first:
+
+```json
+{"uid": "PSUPCLOBS#12",
+ "rationale": "Problem: author states 'graylog doesn't show logs'; no question or consultation/feature/security cue to override; ticket_type not needed.",
+ "intent": "problem", "component": "graylog", "platform": "kubernetes",
+ "phase": "runtime", "symptom": "no_data", "topic": ""}
+```
+
+- `rationale` (1–2 lines) comes first and traces the path: your content read →
+  the signal that adjusted it (if any) → whether `ticket_type` broke a tie. **Quote
+  the decisive cue verbatim** — the exact phrase that fixed the intent (and the
+  cue for a localization axis when not obvious) — so the basis is visible, not
+  paraphrased. It is the model's reasoning, formed before the labels.
+- Localization fields are filled only when `intent != unknown`.
+- A leaf is empty (`""`) when it does not apply to the intent — `symptom` for
+  non-problem intents, `topic` for `problem`. `unknown` means the axis applies
+  but the text did not determine it. There are no confidence fields.

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-classification/references/signals.txt
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-classification/references/signals.txt
@@ -1,0 +1,329 @@
+# signals.txt — single signal dictionary for logging-l1-classification.
+# One phrase per line: case-insensitive, whitespace-flexible, word boundaries
+# at word-char edges. Prefix a line with "re:" for a raw regex. "#" at the
+# start of a line is a comment; no inline trailing comments.
+# Namespaces:
+#   [problem|consultation|feature_request|security]  intent
+#   [component.<name>]                               where in the stack
+#   [platform.<name>]                                where it runs (vm / kubernetes)
+#   [phase.<name>]                                   where in lifecycle (deploy)
+#   [symptom.<name> | .<component>.<spec> | .deploy.<spec>]  problem "what"
+#   [topic.<name>]                                   consultation/feature/security "what"
+# Section hits are HINTS only; the model decides every label.
+
+[problem]
+re: \bfail(?:ed|s|ing)?\b
+re: \bfailure\b
+re: \berror(?:s)?\b
+exception
+re: \bcrash(?:ed|es|ing|loop(?:backoff)?)?\b
+re: \boom(?:killed)?\b
+re: \brestart(?:s|ed|ing)?\b
+stuck
+re: \bhang(?:s|ed|ing)?\b
+re: \b(?:is|are|went|going)\s+down\b
+broken
+re: \btime(?:d)?\s*out|\btimeout\b
+re: \b(?:connection\s+)?refused\b
+unable to
+re: \bcannot\b|\bcan(?:\x27|')?t\b
+re: \bdoes\s*n(?:\x27|')?t\b|\bdoesn[\x27']?t\b
+re: \bdo\s*n(?:\x27|')?t\s+work\b|\bdon[\x27']?t\s+work\b
+re: \bis\s+not\s+working\b|\bnot\s+work(?:ing)?\b
+re: \bnot\s+(?:processing|responding|respond|visible|shown|showing|passed|available|installing|installed|starting|started|written|received|reflect(?:ed|ing)?|created|generated)\b
+re: \bdid(?:\x27|')?n[\x27']?t\s+start\b
+not started
+re: \bstop(?:s|ped|ping)?\s+(?:processing|working|sending|receiving|writing)\b
+re: \bno\s+(?:logs?|data|messages?|stream|output)\b
+empty stream
+empty index
+empty file
+empty response
+unprocessed
+re: \b(?:0|zero)[\s-]*byte\b
+re: \bdelay(?:ed|s|ing)?\b
+slow
+re: \blag(?:s|ged|ging)?\b
+missing
+re: \bhigh\s+(?:cpu|memory|load|amount|disk)\b
+re: \bgrow(?:n|s|ing)?\s+\d+\s*x\b|\b\d+\s*x\s+(?:larger|bigger|more|growth)\b
+re: \bspend(?:s|ing)?\s+(?:more\s+than\s+|over\s+)?\d+\s*(?:sec|second|min|minute|hour)s?\b
+re: \balways\s+yellow\b|\bcluster\s+is\s+(?:yellow|red)\b
+re: (?m)^\s+at\s+[\w$.]+\(
+traceback
+stacktrace
+stack trace
+re: \b[A-Z][\w.]*Exception\b
+
+[consultation]
+re: \bhow\s+(?:to|do|can|should|would)\b
+is it possible
+re: \bcan\s+(?:we|i|you)\b
+re: \bwhere\s+(?:is|can|do|to|should)\b
+re: \bwhat\s+is\b|\bwhich\b
+re: \bwould\s+like\s+to\s+(?:know|understand|learn)\b
+re: \bwant(?:ed)?\s+to\s+(?:know|understand)\b
+re: \bcould\s+you\s+(?:please\s+)?(?:help|advise|explain|share|clarify)\b
+re: \bkindly\s+(?:share|provide|advise|confirm)\b
+re: \bplease\s+(?:advise|confirm|explain|clarify)\b|\badvise\b
+re: \bdon(?:\x27|')?t\s+know\s+(?:where|how|what)\b
+re: \bneed\s+(?:info|information|to\s+know|help\s+understanding|guidance)\b
+re: \bclarif(?:y|ication)\b
+question
+documentation
+re: \bdocs?\b
+re: \brecommend(?:ed|ation)?\b|\bbest\s+practice\b
+
+[feature_request]
+please add
+re: \badd\s+(?:support|ability|an?\s+option|a\s+(?:chapter|section|paragraph))\b
+ability to
+support for
+re: \bwould\s+(?:be|it\s+be)\s+(?:nice|good|great|useful|possible)\b
+feature request
+enhancement
+implement
+re: \bprovide\s+an?\b
+re: \badd\s+.{0,40}\bto\s+(?:the\s+)?logging[-\s]?operator\b
+re: \bdefine\s+(?:the\s+)?contract\b
+re: \bmake\s+.{0,30}\brequirements?\b
+re: \bremov(?:e|al)\s+of\b
+
+[security]
+re: \bvulnerabilit(?:y|ies)\b
+re: \bcve[-\s]?\d|\bcve\b
+re: \bcwe[-\s]?\d|\bcwe\b
+re: \bsecurity\s+(?:scan|scanning|finding|issue|defect|fix|patch)\b
+re: \bsca\b|\bxray\b|\bsnyk\b|\bnessus\b
+re: \bpen(?:etration)?[-\s]?test\b
+re: \bupdate\s+(?:the\s+)?image(?:s)?\b
+re: \bupgrade\s+(?:os\s+)?(?:packages?|libraries|dependenc(?:y|ies))\b
+re: \bpatch\s+(?:the\s+)?(?:image|version|vulnerab\w*)\b
+re: \bfix(?:ing)?\s+(?:the\s+)?(?:cve|vulnerab\w*)\b
+
+[component.graylog]
+graylog
+gl
+
+[component.fluentd]
+re: \bfluent\.?d\b|\btd-agent\b
+re: \bfluent::|\bbufferqueuelimiterror\b|\.rb\b
+
+[component.fluentbit]
+re: \bfluent\s*-?\s*bit\b
+
+[component.opensearch]
+re: \bopensearch\b|\belastic(?:search)?\b|\bes\b
+
+[component.mongodb]
+re: \bmongo(?:db)?\b
+
+[component.events-reader]
+re: \bevents?[-\s]?reader\b|\bcloudeventsreader\b
+
+[component.operator]
+re: \blogging[-\s]?operator\b
+re: \boperator\s+(?:pod|reconcil\w*|controller|crd|cr)\b
+
+[platform.vm]
+re: \bexternal[-\s]?logging[-\s]?installer\b
+re: /srv/docker/graylog\b
+re: \bdocker\s+(?:ps|stats|run|start|container|compose)\b
+re: \blsblk\b|\bdf\s+-h\b
+re: \[(?:root|centos|ubuntu)@
+re: \bgraylog[-\s]?install\b
+re: \bvirtual\s+machine\b|\bon\s+vm\b
+re: \bcreaterepo\b|\byum\s+install\b
+
+[platform.kubernetes]
+re: \bkubernetes\b|\bk8s\b|\bopenshift\b|\bocp\b|\beks\b|\baks\b|\bgke\b
+re: \bkubectl\b|\boc\s+(?:get|logs|describe|adm|project)\b
+re: \bnamespace\b|\bdaemonset\b|\bstatefulset\b
+re: \bhelm(?:file)?\b
+re: \bpods?\b
+re: \bcrashloopbackoff\b
+re: \.openshift\.
+
+[phase.deploy]
+re: \bTASK\s*\[
+re: \bansible\b|\bplaybook\b
+re: \bgraylog[-\s]?install\b|\bgraylog[-\s]?configuration\b|\bprepare[-\s]?env\b
+re: \bdeploy[-\s]?logging[-\s]?service\b
+re: \bdeploy[-\s]?logging[-\s]?application[-\s]?yaml\b
+re: \bexternal[-\s]?logging[-\s]?installer\b
+re: \binstall(?:ation)?\s+(?:of\s+logging\s+)?fail(?:ed|s|ing)?\b
+re: \b(?:up\s*grade|update)\s+(?:of\s+)?logging\b
+re: \bduring\s+(?:install\w*|deploy\w*|upgrad\w*)\b
+
+[symptom.not_running]
+re: \bwo?n[\x27']?t\s+start\b
+not starting
+did not start
+re: \bfail(?:s|ed|ing)?\s+to\s+start\b
+not running
+re: \b(?:is|are)\s+down\b
+crashloop
+re: \bcrash\s*loop(?:backoff)?\b
+keeps restarting
+not coming up
+re: \bpod\s+not\s+ready\b
+
+[symptom.no_data]
+re: \bno\s+(?:logs?|data|messages?|events?)\b
+not forwarded
+not forwarding
+re: \bnot\s+(?:sent|received|delivered|reaching|arriving)\b
+empty stream
+empty index
+logs missing
+re: \blost\s+(?:logs?|messages?|data)\b
+
+[symptom.performance]
+slow
+re: \bslow(?:ness|ly)?\b
+re: \blag(?:s|ging|gy)?\b
+re: \bdelay(?:ed|s|ing)?\b
+high latency
+re: \btimeouts?\b
+
+[symptom.disk_space]
+re: \bdisk\s+(?:full|space|usage)\b
+out of disk
+re: \bno\s+space\s+left\b
+re: \bstorage\s+full\b
+re: \b(?:pvc|volume)\s+full\b
+
+[symptom.oom_memory]
+re: \boom(?:killed)?\b
+out of memory
+re: \bmemory\s+(?:leak|pressure|limit)\b
+high memory
+
+[symptom.data_correctness]
+re: \bparse\s+(?:error|fail\w*)\b
+parsing error
+re: \bmissing\s+fields?\b
+wrong format
+re: \bgarbled\b|\bcorrupt(?:ed)?\b
+re: \bmalformed\b
+
+[symptom.auth_cert]
+re: \bunauthor(?:ized|ised)\b
+re: \bauthentication\s+(?:fail\w*|error)\b
+re: \b40[13]\b
+re: \bcert(?:ificate)?\s+(?:expired|error|invalid)\b
+re: \bcertificate\b
+re: \bx509\b
+re: \btls\s+(?:error|handshake)\b
+permission denied
+re: \bforbidden\b
+re: \brbac\b|\bauthoriz\w*\b
+
+[symptom.config_error]
+re: \binvalid\s+config(?:uration)?\b
+configuration error
+re: \bwrong\s+(?:setting|parameter|value)\b
+bad config
+
+[symptom.graylog.stream_index]
+re: \bstream\b
+re: \bindex\s+(?:set|rotation)\b
+re: \bindices\b
+
+[symptom.graylog.archive]
+re: \barchiv(?:e|ed|ing)\b
+
+[symptom.opensearch.cluster_red_yellow]
+re: \bcluster\s+(?:is\s+)?(?:red|yellow)\b
+re: \b(?:red|yellow)\s+status\b
+
+[symptom.opensearch.shard]
+re: \bunassigned\s+shards?\b
+re: \bshards?\b
+
+[symptom.fluentd.buffer_overflow]
+re: \bbuffer\s+(?:overflow|full|queue)\b
+backpressure
+re: \bchunk\b
+re: \bbufferqueuelimiterror\b
+re: \bqueue\s*size\s*exceeds\b
+re: \bslow\s*flush\b
+
+[symptom.fluentbit.buffer_overflow]
+re: \bbuffer\s+(?:overflow|full)\b
+backpressure
+
+[symptom.mongodb.replica]
+re: \breplica\s*set\b
+re: \bprimary\s+(?:election|stepdown)\b
+
+[symptom.operator.reconcile]
+re: \bcontroller[-\s]*runtime\b
+re: \breconcil(?:e|er|iation|ing)\b
+
+[symptom.deploy.prereq_check]
+re: \bnot\s+enough?\s+hdd\b
+re: \bhdd\s+size\b
+re: \bprerequisites?\b|\bprereq\b
+re: \brequired\s+\d+\s*gb\b
+
+[symptom.deploy.image_unavailable]
+re: \bimage\s+\S+\s+not\s+found\b
+re: \bimagepullbackoff\b|\berrimagepull\b
+re: \bmanifest\s+unknown\b
+
+[symptom.deploy.artifact_fetch]
+re: \bhttp\s+error\s+404\b|\b404\s+not\s+found\b
+re: \bcopy\s+plugins?\b
+re: \bchecksum\b
+
+[symptom.deploy.artifact_corrupt]
+re: \bzipfile\s+is\s+empty\b
+re: \bunzip\b
+re: \bempty\s+archive\b
+
+[symptom.deploy.task_error]
+re: \bmissingproperty\w*\b
+re: \bnullpointerexception\b
+re: \bno\s+such\s+property\b
+re: \bworking\s+directory\b
+
+[symptom.deploy.config_validation]
+re: \bvalidationapierror\b
+re: \binvalid\s+output\s+type\b
+re: \bcannot\s+deserialize\b
+re: \bvalidation\s+failed\b
+
+[symptom.deploy.package_missing]
+re: \bdid(?:n[\x27']?t)?\s+install\b
+re: \bnot\s+install(?:ed)?\s+automatically\b
+
+[symptom.deploy.dependency]
+re: \bcould\s+not\s+find\s+gem\b|\bgems?\s+(?:were\s+)?not\s+found\b
+re: \bno\s+td-agent\b
+
+[topic.backup_restore]
+backup
+re: \brestore\b|\bsnapshot\b
+
+[topic.retention]
+retention
+re: \bhow\s+long\s+.{0,20}\b(?:kept|stored|retained)\b
+
+[topic.output_target]
+re: \bloki\b|\bsplunk\b|\bkafka\b|\bcloudwatch\b
+re: \bsend\s+(?:logs?|data)\s+to\b
+re: \boutput\s+(?:plugin|target|destination)\b
+
+[topic.rbac_auth]
+re: \brbac\b|\baccess\s+control\b
+re: \brole\b|\bpermission\b
+
+[topic.sizing_resources]
+sizing
+re: \bresource\s+(?:request|limit)s?\b
+re: \b(?:cpu|memory)\s+(?:request|limit)s?\b
+
+[topic.integration]
+re: \bintegrat(?:e|ion)\b
+connect to

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-classification/scripts/extract_signals.py
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-classification/scripts/extract_signals.py
@@ -1,0 +1,113 @@
+"""Stage-1 signal extraction for logging-l1-classification.
+
+Deterministic. Parses the line-based signal dictionary (intent-signals.txt)
+and matches ticket text. Standard library only — no third-party deps — so the
+skill runs wherever python3 is present. Produces hints only; the model
+(stage 2) always decides the label.
+
+Dictionary format:
+  # comment (only at start of a line)
+  [problem] / [consultation] / [feature_request] / [security]   intent sections
+  [component.<name>]                                            stack-component sections
+  [platform.<name>]                                             substrate sections (vm / kubernetes)
+  [phase.<name>]                                                lifecycle sections (deploy)
+  [symptom.<name>] / [symptom.<component>.<spec>] / [symptom.deploy.<spec>]
+  [topic.<name>]
+  <phrase>        a literal phrase (case-insensitive, whitespace-flexible,
+                  word boundaries at word-char edges)
+  re: <regex>     a raw regex, compiled case-insensitive, verbatim
+"""
+import argparse
+import json
+import os
+import re
+
+INTENT_CATEGORIES = ("problem", "consultation", "feature_request", "security")
+
+LABEL_NAMESPACES = ("component", "platform", "phase", "symptom", "topic")
+
+_WORD = re.compile(r"\w")
+
+
+def default_signals_path():
+    here = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(here, "..", "references", "signals.txt")
+
+
+def _compile_phrase(phrase):
+    parts = re.split(r"\s+", phrase.strip())
+    body = r"\s+".join(re.escape(p) for p in parts)
+    prefix = r"\b" if _WORD.match(phrase[0]) else ""
+    suffix = r"\b" if _WORD.match(phrase[-1]) else ""
+    return re.compile(prefix + body + suffix, re.IGNORECASE)
+
+
+def load(path=None):
+    """Parse the dictionary into {section_name: [compiled regex, ...]}."""
+    path = path or default_signals_path()
+    sections = {}
+    current = None
+    with open(path, encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("[") and line.endswith("]"):
+                current = line[1:-1].strip()
+                sections.setdefault(current, [])
+                continue
+            if current is None:
+                continue
+            if line.startswith("re:"):
+                sections[current].append(re.compile(line[3:].strip(), re.IGNORECASE))
+            else:
+                sections[current].append(_compile_phrase(line))
+    return sections
+
+
+def _dedup(seq):
+    seen = set()
+    out = []
+    for item in seq:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def match_text(text, sections):
+    text = text or ""
+    result = {}
+    for cat in INTENT_CATEGORIES:
+        hits = []
+        for rx in sections.get(cat, []):
+            hits.extend(m.group(0) for m in rx.finditer(text))
+        result[cat] = _dedup(hits)
+    for ns in LABEL_NAMESPACES:
+        prefix = ns + "."
+        labels = []
+        for name, regexes in sections.items():
+            if not name.startswith(prefix):
+                continue
+            label = name[len(prefix):]
+            if any(rx.search(text) for rx in regexes):
+                labels.append(label)
+        result[ns] = _dedup(labels)
+    return result
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Stage-1 signal extraction for logging-l1-classification."
+    )
+    ap.add_argument("ticket_file", help="file holding one ticket's text (Summary + Description)")
+    ap.add_argument("--signals", default=None, help="path to intent-signals.txt")
+    args = ap.parse_args(argv)
+    with open(args.ticket_file, encoding="utf-8") as fh:
+        text = fh.read()
+    print(json.dumps(match_text(text, load(args.signals)), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/SKILL.md
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: logging-l1-outcome
+description: First-hop disposition of a classified Qubership logging-stack support ticket. Use after logging-l1-classification has labeled a ticket, to decide the next action — ask the author for missing data (Additional Info Required), flag a suspected known issue with a draft reply (Suspected Known Issue), or hand a structured packet to L2 (Handoff to L2). Reads ticket content and attachments (logs, screenshots); never touches live systems, mutates the ticket, or closes it.
+---
+
+# logging-l1-outcome
+
+## What this does
+
+Take a ticket already classified by `logging-l1-classification` and decide ONE
+operator-facing disposition. Do not re-classify. First hop of an L1 pipeline; L2
+troubleshooting is a later hop.
+
+## Hard rules
+
+- **No system access, no mutation, no ticket closure.** Reading attachments and
+  static docs is fine; querying or changing live systems is not.
+  `suspected_known_issue` drafts a reply and recommends — the operator confirms
+  and closes.
+- **One round of data request.** If the first `additional_info_required` round is
+  answered and data is still short, hand off — do not keep interviewing.
+- **Evidence-backed.** Every fact you pass is quoted verbatim with its source (a
+  log line, a one-line screenshot description). Use only described `rca-cases`;
+  never invent a cause or a mutating action.
+
+## Inputs
+
+- The `logging-l1-classification` JSON: `intent, component, platform, phase, symptom,
+  topic` — the verdict; do not revisit it.
+- The ticket text: `Summary` + `Description` + `Steps to Reproduce`.
+- Attachments: logs (text) and screenshots/images where you can read images.
+
+## Reading evidence — what counts as present
+
+When you check whether a required fact is present, read the ticket text and
+attachments together. Two rules decide presence:
+
+- **Inline evidence is the evidence.** A log line, stack trace, or console block
+  pasted into the ticket (`{code}`, `{noformat}`, `Exception`, `Caused by`,
+  `Traceback`) IS the "logs" fact. Treat it as present and read it directly.
+- **A referenced attachment is a provided fact.** A Jira embed or attachment link
+  (`!file.png!`, `[^file.log]`) or a prose reference ("attached", "screenshot",
+  "во вложении") means the author supplied that fact. Treat it as present even
+  when you cannot open the file. Do not re-request it.
+
+## Step 0 — match known problems (mechanical)
+
+Write the ticket text plus any attachment text to a temp file and run the bundled
+matcher (use this skill's base directory, shown when it loads):
+
+```bash
+python3 <skill-dir>/scripts/match_rca.py /tmp/ticket.txt
+```
+
+It prints the ids of any `references/rca-cases.txt` patterns that fired. For each
+matched id, read its cause and draft reply in `references/rca-cases.md`. A match
+is a HINT — confirm the case truly applies (its caveat holds) before using it.
+
+## Decision flow — stop at the first that fires
+
+1. **Suspected known issue.** A matched `rca-cases` entry truly applies (its
+   caveat holds) → `suspected_known_issue`: emit the probable cause and the draft
+   reply. For `consultation`, a documentation answer found in the bundled docs
+   counts here too.
+2. **Additional info required.** No match → check the collected facts (applying
+   the evidence rules above) against `references/facts-required.md` for this
+   localization. For each required `field-id` still missing, read its collection
+   steps for the ticket platform in `references/collection-howto.md` and weave them
+   into the message to the author. → `additional_info_required`, listing only the
+   missing field-ids. One round only.
+3. **Handoff to L2.** Facts present, no L1 resolution → `handoff_to_l2`.
+
+## Output
+
+Emit one YAML block, `outcome` first. Pick the shape for the outcome.
+
+`suspected_known_issue` — a suggestion the operator confirms:
+
+```yaml
+outcome: suspected_known_issue
+case_id: index-read-only-after-disk-cleanup
+cause: "Index left read-only after a disk fill; OpenSearch does not clear the flag."
+draft_reply: |
+  <reply to the author, in their language>
+recommend: close_after_confirmation
+```
+
+`additional_info_required` — the missing field-ids, plus a ready message:
+
+```yaml
+outcome: additional_info_required
+missing:
+  - logging_version
+  - configmap_fluent
+message_to_author: |
+  <a short message in the author's language that asks only for the missing fields
+  AND, for each, the collection steps from collection-howto.md for this platform>
+```
+
+`handoff_to_l2` — the structured packet (routed by `logging-l2-triage`):
+
+```yaml
+outcome: handoff_to_l2
+localization: {component: fluentbit, platform: kubernetes, phase: runtime, symptom: no_data}
+facts:
+  error_text: "connection timeout to tcp://graylog:12201"   # fluentbit.log
+  affected_scope: "namespace payments"                       # Description
+  logging_version: "14.6.0"                                  # Description
+sources: [fluentbit.log]
+```
+
+Rules: `facts` are quoted verbatim with their source (the trailing `# source`
+comment); a one-line description stands in for a screenshot. No binaries and no
+`attachments` field — the raw files stay on the ticket for L2. Priority is L2's
+call.

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/collection-howto.md
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/collection-howto.md
@@ -1,0 +1,119 @@
+# collection-howto — how to collect each required field
+
+For each `field-id` listed as missing, read its section and use the steps for the
+ticket platform. Weave them into the message to the author. Placeholders like
+`<pod>` are filled by the author with their own values. Prose-only fields need no
+collection — the author just states them in the ticket.
+
+## description
+
+State in the ticket what is wrong, what was expected, and when it started. No collection needed.
+
+## deployment_params
+
+**kubernetes:** Export the CR: `kubectl -n logging get loggingservice -o yaml`.
+**vm:** Attach the deploy parameters used for the install (inventory or job parameters).
+
+## logging_version
+
+**kubernetes:** The operator image tag (or the `version` in the CR):
+`kubectl -n logging get deploy logging-operator -o jsonpath='{.spec.template.spec.containers[0].image}'`.
+**vm:** The `application_version` from the deploy parameters (e.g. the `deploy-logging-service` job).
+
+## steps_to_reproduce
+
+List the exact actions that trigger the problem, in order. No collection needed.
+
+## environment_link
+
+Paste a link to the affected environment (Graylog UI, cluster console, or pipeline). No collection needed.
+
+## expected_behavior
+
+State what you expected to happen and why, so the gap is clear. No collection needed.
+
+## cve_report
+
+Attach the vulnerability report — the CVE list or SCA / scanner output (e.g. XRAY) for the scanned version.
+
+## deployment_type
+
+State whether the install is driven by ArgoCD or by a Groovy pipeline.
+
+## deployment_mode
+
+State whether this was a clean install or a rolling update.
+
+## deployment_logs
+
+**kubernetes:** Attach the pipeline log of the failed deploy, or a link to the run.
+**vm:** Attach the `deploy-logging-service` job log, or a link to the run.
+
+## operator_logs
+
+**kubernetes:** `kubectl -n logging logs deploy/logging-operator --tail=2000`.
+
+## service_logs
+
+**kubernetes:** `kubectl -n logging logs -l name=<workload> --previous --tail=2000`
+for each restarting service — workloads are `graylog` (StatefulSet),
+`logging-fluentd` and `logging-fluentbit` (DaemonSets).
+**vm:** `docker logs --tail 2000 <container>` for the failed Graylog-stack
+container — `graylog_graylog_1`, `graylog_elasticsearch_1`, `graylog_mongo_1`,
+`graylog_web_1`.
+
+## pod_yaml
+
+**kubernetes:** `kubectl -n logging get pod -l name=<workload> -o yaml` for each
+restarted service (`graylog`, `logging-fluentd`, `logging-fluentbit`).
+
+## configmap_fluent
+
+**kubernetes:** `kubectl -n logging get cm logging-fluentbit logging-fluentd -o yaml`.
+**vm:** Attach the FluentBit / FluentD config files from the agent host that ships to this Graylog.
+
+## dashboards
+
+**kubernetes:** Attach the runtime and Graylog-metrics dashboard screenshots, or a Grafana link covering the incident window.
+**vm:** Attach the same metrics screenshots if monitoring is available, or a Grafana link.
+
+## ssh_access
+
+**vm:** Provide SSH access to the VM (keys) so the logs and config can be read directly.
+
+## container_logs
+
+**vm:** `docker logs --tail 2000 <container>` for each failed or restarting
+container — e.g. `graylog_graylog_1`, `graylog_elasticsearch_1`,
+`graylog_mongo_1`, `graylog_web_1`.
+
+## affected_scope
+
+Name the namespace and service that have no logs. No collection needed.
+
+## lost_logs_example
+
+**kubernetes:** Provide an example of the missing logs from the node: `/var/log/pods/<namespace>_<pod>_<container_id>/`.
+**vm:** Provide an example of the missing source logs from the application host.
+
+## where_not_seen
+
+State where you do not see the logs (Graylog UI, Grafana, etc.). No collection needed.
+
+## query_used
+
+Paste the exact query you used to select the logs. No collection needed.
+
+## graylog_fluent_logs
+
+**kubernetes:** `kubectl -n logging logs -l name=graylog` and
+`kubectl -n logging logs -l name=logging-fluentbit` (or `logging-fluentd`),
+around the incident time.
+**vm:** `docker logs graylog_graylog_1` (and `graylog_elasticsearch_1` for
+indexing errors), around the incident time. FluentBit / FluentD run on the
+source side, not on the Graylog VM.
+
+## source_vs_graylog_logs
+
+Provide an example of the source logs and the same lines as they appear in Graylog, so the delay or gap is visible.
+</content>

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/facts-required.md
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/facts-required.md
@@ -1,0 +1,85 @@
+# facts-required — what data L1 needs, keyed by localization
+
+Look up by the `logging-l1-classification` localization. The baseline applies to any
+`problem`; the phase/symptom rows add fields on top. `platform=kubernetes` is the
+in-cluster Logging install; `platform=vm` is External Logging. Each line is
+`field-id: description`; the collection steps for each id live in
+`collection-howto.md`. Used two ways:
+
+- additional_info_required: list the baseline + matching-row ids that are MISSING.
+- handoff_to_l2: those same ids, now collected, go into the packet `facts`.
+
+## Baseline — intent=problem
+
+- description: what is wrong, what was expected, when it started
+- deployment_params: deployment parameters or the `LoggingService` CR
+- logging_version: the Logging version in use
+- steps_to_reproduce: the actions that trigger the problem (if available)
+- environment_link: a link to the affected environment (if available)
+
+## intent=consultation
+
+- description: what the reporter wants to know
+- logging_version: the Logging version in use
+- environment_link: a link to the affected environment (if available)
+
+## intent=feature_request
+
+- description: the requested change
+- logging_version: the Logging version in use
+- expected_behavior: what the reporter expects and why
+
+## intent=security
+
+- logging_version: the Logging version used for the scan
+- cve_report: the vulnerability report (CVE / SCA list)
+
+## phase=deploy, platform=kubernetes
+
+- logging_version: the Logging version being installed
+- deployment_type: ArgoCD or Groovy
+- deployment_mode: clean install or rolling update
+- deployment_params: the deployment parameters
+- deployment_logs: deployment logs or an accessible pipeline link
+- operator_logs: logs from logging-operator
+- service_logs: logs from the failed services
+
+## phase=deploy, platform=vm
+
+- logging_version: the Logging version being installed
+- deployment_params: the deployment parameters
+- ssh_access: SSH access to the VM (keys)
+- deployment_logs: deployment logs or an accessible pipeline link
+
+## symptom=oom_memory or not_running, platform=kubernetes
+
+- logging_version: the Logging version in use
+- deployment_type: ArgoCD or Groovy
+- deployment_params: the deployment parameters
+- service_logs: logs from the restarting services
+- pod_yaml: pod YAML of the restarted services
+- configmap_fluent: the FluentBit / FluentD ConfigMap
+- dashboards: runtime + Graylog metrics screenshots or a Grafana link
+
+## symptom=not_running, platform=vm
+
+- logging_version: the Logging version in use
+- deployment_params: the deployment parameters
+- ssh_access: SSH access to the VM (keys)
+- container_logs: logs from the failed / restarting containers
+
+## symptom=no_data
+
+- logging_version: the Logging version in use
+- deployment_params: the deployment parameters
+- affected_scope: which namespace and service has no logs
+- lost_logs_example: an example of the lost logs
+- where_not_seen: where the logs are not seen (Graylog UI, Grafana, etc.)
+- query_used: the query used to select logs
+- graylog_fluent_logs: logs from Graylog and FluentBit / FluentD
+- configmap_fluent: the FluentBit / FluentD ConfigMap
+
+## symptom=performance (log delay / time gap)
+
+- source_vs_graylog_logs: source logs and the same lines from Graylog
+- configmap_fluent: the FluentBit / FluentD ConfigMap

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/rca-cases.md
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/rca-cases.md
@@ -1,0 +1,85 @@
+# rca-cases — cause and draft reply per known problem
+
+For each case id that `scripts/match_rca.py` returns, read the matching section
+below. A match is a hint: use the case only when its caveat holds, and emit the
+draft reply as a suggestion the operator confirms. Placeholders like
+`{{opensearch_url}}` are filled by the operator when the value is not in the ticket.
+
+## ism-config-cosmetic
+
+**Cause:** cosmetic bug in the OpenSearch index-management plugin before
+2.10.0.0 — logged at ERROR but should be DEBUG. No functional impact, no
+data loss.
+**Reply:** This is a known cosmetic log line, not a fault. Ignore it, or
+create any ISM policy (even an empty one) to make the index appear and
+silence it.
+**Caveat:** none.
+
+## timestamp-tz-mismatch
+
+**Cause:** the Graylog UI renders `timestamp` in the viewer's timezone while
+the `message` text keeps the source application's timezone. Not a logging
+defect.
+**Reply:** Align them either by setting the node timezone to UTC, or by
+changing the Graylog user's display timezone (this only affects how
+`timestamp` is shown, never the `message` text).
+**Caveat:** if the author insists the `message` text itself is rewritten,
+this case does not apply — hand off to L2.
+
+## deflector-exists-as-index
+
+**Cause:** the `_deflector` suffix is reserved by Graylog; an index with that
+suffix was created (usually because inputs were not stopped during an
+upgrade), so the alias cannot attach.
+**Reply:** Delete the offending index. For future upgrades, stop the Graylog
+inputs first so this does not recur.
+**Caveat:** if the operator cannot confirm which index is offending, or
+deleting it risks log loss, this case does not apply — hand off to L2.
+
+## fields-limit-1000-exceeded
+
+**Cause:** older Logging versions let the FluentBit/FluentD parser extract
+noisy `key=value` pairs that explode the index mapping until the 1000-field
+limit is hit.
+**Reply:** Upgrade Logging to a version with the fixed parser. The
+accumulated noise fields can be cleaned with the painless script in the
+runbook.
+**Caveat:** none.
+
+## dr-no-vip-cyclic-redirect
+
+**Cause:** DR no-vIP topology with a Load Balancer plus HTTPS termination —
+the Graylog UI is reachable only when SNI passthrough is configured for the
+Graylog route.
+**Reply:** Add the Graylog Route URL to `os_sni_passthrough.map` on the Load
+Balancers and retry.
+**Caveat:** only the DR no-vIP topology. If the install uses a vIP or a
+different LB product, this case does not apply — hand off to L2.
+
+## index-read-only-after-disk-cleanup
+
+**Cause:** after a disk fill, OpenSearch sets the index read-only flag and
+does not clear it automatically once space is freed.
+**Reply:** Clear it against the OpenSearch endpoint, then keep all index sets
+under ~85% of the data disk so it does not recur:
+
+```sh
+curl -X PUT -H 'Content-Type: application/json' \
+  -d '{"index.blocks.read_only_allow_delete": null}' \
+  '{{opensearch_url}}/_all/_settings'
+```
+
+**Caveat:** only trivial once the author confirms the disk is below the
+watermark. If the disk is still full, hand off to L2 for the
+capacity/rotation issue.
+
+## nodes-info-unavailable-tls
+
+**Cause:** usually an expired TLS certificate, or one missing the required
+Subject Alternative Names (e.g. `graylog-service.<namespace>.svc`).
+**Reply:** Re-issue the certificate with the correct alt names and restart
+the Graylog service so the new cert loads.
+**Caveat:** match only when the ticket mentions TLS, an expired cert, or
+shows a cert error. The same message can come from an OpenSearch outage —
+that is not this case; hand off to L2.
+</content>

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/rca-cases.txt
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/references/rca-cases.txt
@@ -1,0 +1,32 @@
+# rca-cases.txt — curated known-problem patterns for logging-l1-outcome.
+# Same line format as the intent skill's signals.txt: one [<case-id>] section per
+# known problem; a bare line is a case-insensitive phrase, an "re:" line is a raw
+# regex. Matched against the ticket text and attachment text. A match is a HINT —
+# the model reads references/rca-cases.md for the matched case's cause and draft
+# reply and confirms the caveat holds before using it.
+
+[ism-config-cosmetic]
+IndexNotFoundException [.opendistro-ism-config]
+re: \bopendistro-ism-config\b
+
+[timestamp-tz-mismatch]
+different times in message and timestamp
+time mismatch between message and timestamp
+log time in message differs from time field
+
+[deflector-exists-as-index]
+Deflector exists as an index and is not an alias
+
+[fields-limit-1000-exceeded]
+re: Limit of total fields \[1000\] in index has been exceeded
+
+[dr-no-vip-cyclic-redirect]
+cyclic redirect
+redirect loop on Graylog UI
+
+[index-read-only-after-disk-cleanup]
+index.blocks.read_only_allow_delete
+re: FORBIDDEN/12/index read-only
+
+[nodes-info-unavailable-tls]
+Nodes info unavailable

--- a/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/scripts/match_rca.py
+++ b/agent-packages/logging-l1-triage/.apm/skills/logging-l1-outcome/scripts/match_rca.py
@@ -1,0 +1,80 @@
+"""Deterministic RCA-case matcher for logging-l1-outcome.
+
+Mirrors the intent skill's extract_signals.py. Parses the line-based
+rca-cases.txt (one [<case-id>] section per known problem, with bare phrase or
+"re:" regex lines) and returns the ids of cases whose pattern matches the ticket
+text (plus any attachment text). Standard library only. A match is a HINT — the
+model reads references/rca-cases.md for the matched case's cause and draft reply
+and decides whether it truly applies.
+"""
+import argparse
+import json
+import os
+import re
+
+_WORD = re.compile(r"\w")
+
+
+def default_cases_path():
+    here = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(here, "..", "references", "rca-cases.txt")
+
+
+def _compile_phrase(phrase):
+    parts = re.split(r"\s+", phrase.strip())
+    body = r"\s+".join(re.escape(p) for p in parts)
+    prefix = r"\b" if _WORD.match(phrase[0]) else ""
+    suffix = r"\b" if _WORD.match(phrase[-1]) else ""
+    return re.compile(prefix + body + suffix, re.IGNORECASE)
+
+
+def load(path=None):
+    """Parse rca-cases.txt into {case_id: [compiled regex, ...]}."""
+    path = path or default_cases_path()
+    cases = {}
+    current = None
+    with open(path, encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("[") and line.endswith("]"):
+                current = line[1:-1].strip()
+                cases.setdefault(current, [])
+                continue
+            if current is None:
+                continue
+            if line.startswith("re:"):
+                cases[current].append(re.compile(line[3:].strip(), re.IGNORECASE))
+            else:
+                cases[current].append(_compile_phrase(line))
+    return cases
+
+
+def match_text(text, cases):
+    """Return ids of cases with at least one matching pattern, dedup, in order."""
+    text = text or ""
+    out = []
+    seen = set()
+    for cid, regexes in cases.items():
+        if cid in seen:
+            continue
+        if any(rx.search(text) for rx in regexes):
+            seen.add(cid)
+            out.append(cid)
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="RCA-case matcher for logging-l1-outcome.")
+    ap.add_argument("ticket_file", help="file with ticket text (+ attachment text)")
+    ap.add_argument("--cases", default=None, help="path to rca-cases.txt")
+    args = ap.parse_args(argv)
+    with open(args.ticket_file, encoding="utf-8") as fh:
+        text = fh.read()
+    print(json.dumps(match_text(text, load(args.cases)), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-packages/logging-l1-triage/README.md
+++ b/agent-packages/logging-l1-triage/README.md
@@ -1,0 +1,67 @@
+# logging-l1-triage
+
+L1 triage pipeline for incoming Qubership logging-stack support tickets
+(Graylog, FluentD, FluentBit, OpenSearch, MongoDB, the logging operator,
+the Helm chart, and the Ansible installer). It runs in two coordinated
+steps: first classify the ticket, then decide what to do with it.
+
+The pipeline is **read-only against live systems**. It does not run
+`kubectl`, SSH, or any diagnostic command; it does not change
+configuration; and it never mutates or closes the ticket. State-changing
+work belongs to L2.
+
+## Skills
+
+| Skill                                                                         | Step     | What it does                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`logging-l1-classification`](.apm/skills/logging-l1-classification/SKILL.md) | Classify | Reads the ticket and emits one `intent` (`problem` / `consultation` / `feature_request` / `security` / `unknown`) plus a uniform localization — `component`, `platform`, `phase`, and a `symptom` or `topic`. |
+| [`logging-l1-outcome`](.apm/skills/logging-l1-outcome/SKILL.md)               | Dispose  | Takes the classified ticket and picks one disposition: `additional_info_required`, `suspected_known_issue` (cause + draft reply), or `handoff_to_l2` (structured packet).                                     |
+
+`logging-l1-classification` runs first; `logging-l1-outcome` consumes its
+verdict. The split is for clarity — the value the package delivers is the
+end-to-end triage.
+
+## Layout
+
+```text
+agent-packages/logging-l1-triage/
+├── apm.yml
+├── README.md
+└── .apm/
+    ├── instructions/
+    │   └── logging-l1-triage.instructions.md   # both triggers, merged into AGENTS.md / CLAUDE.md
+    └── skills/
+        ├── logging-l1-classification/
+        │   ├── SKILL.md
+        │   ├── references/signals.txt          # signal dictionary
+        │   └── scripts/extract_signals.py      # mechanical signal extractor (step 1)
+        └── logging-l1-outcome/
+            ├── SKILL.md
+            ├── references/
+            │   ├── rca-cases.md                # known cases: cause + draft reply
+            │   ├── rca-cases.txt               # matcher patterns
+            │   ├── facts-required.md           # field-ids needed per localization
+            │   └── collection-howto.md         # how to collect each field-id, per platform
+            └── scripts/match_rca.py            # mechanical rca-cases matcher (step 0)
+```
+
+## Install
+
+```sh
+apm install Netcracker/qubership-logging-operator/agent-packages/logging-l1-triage
+apm compile
+```
+
+`apm compile` merges both triggers into your local `AGENTS.md` /
+`CLAUDE.md`.
+
+## Scope and limits
+
+- One round of data requests. If the first `additional_info_required`
+  round comes back still short, the pipeline hands off to L2 rather than
+  interviewing further.
+- Evidence-backed. Every fact passed on is quoted verbatim with its
+  source; the pipeline uses only described `rca-cases` and never invents
+  a cause or a mutating action.
+- `unknown` is the only "not sure" value in classification — precision
+  over recall, and it stops the localization drilldown for that axis.

--- a/agent-packages/logging-l1-triage/apm.yml
+++ b/agent-packages/logging-l1-triage/apm.yml
@@ -1,0 +1,4 @@
+name: logging-l1-triage
+version: 0.1.0
+description: L1 triage pipeline for Qubership logging-stack support tickets — classify the ticket, then decide the next action (request missing data, flag a suspected known issue, or hand off to L2). Two coordinated skills, read-only against live systems; never mutates or closes the ticket.
+author: Qubership


### PR DESCRIPTION
## What

Adds the `logging-l1-triage` APM package — the L1 triage pipeline for incoming
Qubership logging-stack support tickets. Two coordinated, read-only skills:

- `logging-l1-classification` — classifies a ticket's `intent` and emits a
  uniform localization (component / platform / phase / symptom or topic).
- `logging-l1-outcome` — picks one disposition: `additional_info_required`,
  `suspected_known_issue` (cause + draft reply), or `handoff_to_l2` (structured
  packet).

The pipeline is read-only against live systems: no `kubectl`, no SSH, no config
changes, and it never mutates or closes the ticket. State-changing work belongs
to L2.

## Why

L1 triage is the first hop for logging-stack tickets, and today it is manual.
This package gives a weak production model a tight, evidence-backed procedure so
the classification and the next action stay consistent and traceable.

## How to verify

```sh
apm install Netcracker/qubership-logging-operator/agent-packages/logging-l1-triage
apm compile
```

The mechanical helpers run standalone:

```sh
python3 .apm/skills/logging-l1-classification/scripts/extract_signals.py /tmp/ticket.txt
python3 .apm/skills/logging-l1-outcome/scripts/match_rca.py /tmp/ticket.txt
```

## Scope

Skill package only — one commit, 12 files under `agent-packages/logging-l1-triage/`.