### PR TITLE
feat: move sensitive data to secret (FluentD part) 2

### DIFF
--- a/api/v1/loggingservice_types.go
+++ b/api/v1/loggingservice_types.go
@@ -518,13 +518,6 @@ type Auth struct {
 	Token    *v1.SecretKeySelector `yaml:"token" json:"token,omitempty"`
 	User     *v1.SecretKeySelector `yaml:"username" json:"user,omitempty"`
 	Password *v1.SecretKeySelector `yaml:"password" json:"password,omitempty"`
-
-	// TokenValue, UserValue and PasswordValue hold values resolved by the
-	// controller from referenced Secrets at render time. They are not persisted
-	// to the CRD and are used only in generated configuration Secrets.
-	TokenValue    string `json:"-" yaml:"-"`
-	UserValue     string `json:"-" yaml:"-"`
-	PasswordValue string `json:"-" yaml:"-"`
 }
 
 type FluentbitHTTPRouting struct {

--- a/api/v1/loggingservice_types.go
+++ b/api/v1/loggingservice_types.go
@@ -518,6 +518,13 @@ type Auth struct {
 	Token    *v1.SecretKeySelector `yaml:"token" json:"token,omitempty"`
 	User     *v1.SecretKeySelector `yaml:"username" json:"user,omitempty"`
 	Password *v1.SecretKeySelector `yaml:"password" json:"password,omitempty"`
+
+	// TokenValue, UserValue and PasswordValue hold values resolved by the
+	// controller from referenced Secrets at render time. They are not persisted
+	// to the CRD and are used only in generated configuration Secrets.
+	TokenValue    string `json:"-" yaml:"-"`
+	UserValue     string `json:"-" yaml:"-"`
+	PasswordValue string `json:"-" yaml:"-"`
 }
 
 type FluentbitHTTPRouting struct {

--- a/charts/qubership-logging-operator/templates/integration-tests/deployment.yaml
+++ b/charts/qubership-logging-operator/templates/integration-tests/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - name: OPERATION_RETRY_INTERVAL
               value: {{ .Values.integrationTests.operationRetryInterval | default "5s" | quote }}
             - name: OPERATION_RETRY_COUNT
-              value: {{ .Values.integrationTests.operationRetryInterval | default "60x" | quote }}
+              value: {{ .Values.integrationTests.operationRetryCount | default "60x" | quote }}
             - name: OPENSHIFT_DEPLOY
               value: {{ (.Capabilities.APIVersions.Has "security.openshift.io/v1") | default "false" | quote }}
             - name: STATUS_WRITING_ENABLED

--- a/charts/qubership-logging-operator/values.yaml
+++ b/charts/qubership-logging-operator/values.yaml
@@ -2000,6 +2000,12 @@ integrationTests:
   # -- The parameter specifies the timeout before the start of integration tests.
   timeoutBeforeStart: 100
 
+  # -- Robot Framework retry count for integration test operations (e.g. 60x).
+  operationRetryCount: 60x
+
+  # -- Robot Framework retry interval for integration test operations (e.g. 5s).
+  operationRetryInterval: 5s
+
   # -- Flag for specify kind of Graylog (internal in cloud or external on VM).
   externalGraylogServer: "true"
 

--- a/controllers/fluentd/assets/daemon-set.yaml
+++ b/controllers/fluentd/assets/daemon-set.yaml
@@ -136,40 +136,6 @@ spec:
               value: '16777216'
             - name: RUBY_GC_OLDMALLOC_LIMIT_MAX
               value: '16777216'
-{{- if and .Values.Fluentd.Output .Values.Fluentd.Output.Loki .Values.Fluentd.Output.Loki.Enabled }}
-{{- if and .Values.Fluentd.Output.Loki.Auth .Values.Fluentd.Output.Loki.Auth.User .Values.Fluentd.Output.Loki.Auth.User.Name .Values.Fluentd.Output.Loki.Auth.User.Key .Values.Fluentd.Output.Loki.Auth.Password .Values.Fluentd.Output.Loki.Auth.Password.Name .Values.Fluentd.Output.Loki.Auth.Password.Key }}
-            - name: LOKI_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.Fluentd.Output.Loki.Auth.User.Name }}
-                  key: {{ .Values.Fluentd.Output.Loki.Auth.User.Key }}
-            - name: LOKI_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.Fluentd.Output.Loki.Auth.Password.Name }}
-                  key: {{ .Values.Fluentd.Output.Loki.Auth.Password.Key }}
-{{- end }}
-{{- end }}
-{{- if and .Values.Fluentd.Output .Values.Fluentd.Output.Http .Values.Fluentd.Output.Http.Enabled }}
-{{- if and .Values.Fluentd.Output.Http.Auth .Values.Fluentd.Output.Http.Auth.User .Values.Fluentd.Output.Http.Auth.User.Name .Values.Fluentd.Output.Http.Auth.User.Key .Values.Fluentd.Output.Http.Auth.Password .Values.Fluentd.Output.Http.Auth.Password.Name .Values.Fluentd.Output.Http.Auth.Password.Key }}
-            - name: HTTP_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.Fluentd.Output.Http.Auth.User.Name }}
-                  key: {{ .Values.Fluentd.Output.Http.Auth.User.Key }}
-            - name: HTTP_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.Fluentd.Output.Http.Auth.Password.Name }}
-                  key: {{ .Values.Fluentd.Output.Http.Auth.Password.Key }}
-{{- else if and .Values.Fluentd.Output.Http.Auth .Values.Fluentd.Output.Http.Auth.Token .Values.Fluentd.Output.Http.Auth.Token.Name .Values.Fluentd.Output.Http.Auth.Token.Key }}
-            - name: HTTP_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.Fluentd.Output.Http.Auth.Token.Name }}
-                  key: {{ .Values.Fluentd.Output.Http.Auth.Token.Key }}
-{{- end }}
-{{- end }}
           volumeMounts:
 {{ if eq .Values.ContainerRuntimeType "docker" }}
 {{ if ne .Values.OSKind "ubuntu" }}
@@ -228,12 +194,6 @@ spec:
 {{ end }}
 {{ end }}
 {{- if and .Values.Fluentd.Output .Values.Fluentd.Output.Loki .Values.Fluentd.Output.Loki.Enabled }}
-{{- if and .Values.Fluentd.Output.Loki.Auth .Values.Fluentd.Output.Loki.Auth.Token .Values.Fluentd.Output.Loki.Auth.Token.Name .Values.Fluentd.Output.Loki.Auth.Token.Key }}
-            - mountPath: /fluentd/output/loki/auth/token
-              name: loki-auth-token
-              readOnly: true
-              subPath: {{ .Values.Fluentd.Output.Loki.Auth.Token.Key }}
-{{- end }}
 {{- if and .Values.Fluentd.Output.Loki.TLS .Values.Fluentd.Output.Loki.TLS.Enabled }}
 {{- if and .Values.Fluentd.Output.Loki.TLS.CA .Values.Fluentd.Output.Loki.TLS.CA.SecretName .Values.Fluentd.Output.Loki.TLS.CA.SecretKey }}
             - mountPath: /fluentd/output/loki/tls/ca.crt
@@ -303,8 +263,8 @@ spec:
             path: "/var/log"
             type: ""
         - name: config
-          configMap:
-            name: "logging-fluentd"
+          secret:
+            secretName: "logging-fluentd"
             defaultMode: 420 # RW grants for config map files
 {{ if .Values.Fluentd.TLS }}
 {{ if and .Values.Fluentd.TLS.GenerateCerts .Values.Fluentd.TLS.GenerateCerts.Enabled }}
@@ -342,12 +302,6 @@ spec:
 {{ end }}
 {{ end }}
 {{- if and .Values.Fluentd.Output .Values.Fluentd.Output.Loki .Values.Fluentd.Output.Loki.Enabled }}
-{{- if and .Values.Fluentd.Output.Loki.Auth .Values.Fluentd.Output.Loki.Auth.Token .Values.Fluentd.Output.Loki.Auth.Token.Name .Values.Fluentd.Output.Loki.Auth.Token.Key }}
-        - name: loki-auth-token
-          secret:
-            secretName: {{ .Values.Fluentd.Output.Loki.Auth.Token.Name }}
-            defaultMode: 220
-{{- end }}
 {{- if and .Values.Fluentd.Output.Loki.TLS .Values.Fluentd.Output.Loki.TLS.Enabled }}
 {{- if and .Values.Fluentd.Output.Loki.TLS.CA .Values.Fluentd.Output.Loki.TLS.CA.SecretName .Values.Fluentd.Output.Loki.TLS.CA.SecretKey }}
         - name: loki-tls-ca

--- a/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-http.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-http.conf
@@ -8,8 +8,8 @@
   {{- if and .Values.Fluentd.Output.Http.Auth .Values.Fluentd.Output.Http.Auth.User .Values.Fluentd.Output.Http.Auth.Password }}
   <auth>
     method     basic
-    username   {{ .Values.Fluentd.Output.Http.Auth.UserValue | quote }}
-    password   {{ .Values.Fluentd.Output.Http.Auth.PasswordValue | quote }}
+    username   {{ .OutputCredentials.Http.User | quote }}
+    password   {{ .OutputCredentials.Http.Password | quote }}
   </auth>
   {{- end }}
   {{- $headers := dict "VL-Msg-Field" "log" "VL-Time-Field" "time" "VL-Stream-Fields" "namespace,container" }}
@@ -17,7 +17,7 @@
   {{- $headers = deepCopy .Values.Fluentd.Output.Http.Headers }}
   {{- end }}
   {{- if and .Values.Fluentd.Output.Http.Auth .Values.Fluentd.Output.Http.Auth.Token }}
-  {{- $_ := set $headers "Authorization" (printf "Bearer %s" .Values.Fluentd.Output.Http.Auth.TokenValue) }}
+  {{- $_ := set $headers "Authorization" (printf "Bearer %s" .OutputCredentials.Http.Token) }}
   {{- end }}
   headers      {{ $headers | toJson }}
   {{- if .Values.Fluentd.Output.Http.Routing }}

--- a/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-http.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-http.conf
@@ -8,15 +8,18 @@
   {{- if and .Values.Fluentd.Output.Http.Auth .Values.Fluentd.Output.Http.Auth.User .Values.Fluentd.Output.Http.Auth.Password }}
   <auth>
     method     basic
-    username   "#{ENV['HTTP_USERNAME']}"
-    password   "#{ENV['HTTP_PASSWORD']}"
+    username   {{ .Values.Fluentd.Output.Http.Auth.UserValue | quote }}
+    password   {{ .Values.Fluentd.Output.Http.Auth.PasswordValue | quote }}
   </auth>
   {{- end }}
+  {{- $headers := dict "VL-Msg-Field" "log" "VL-Time-Field" "time" "VL-Stream-Fields" "namespace,container" }}
   {{- if .Values.Fluentd.Output.Http.Headers }}
-  headers      {{ .Values.Fluentd.Output.Http.Headers | toJson }}
-  {{- else }}
-  headers      {{ printf `{"VL-Msg-Field": "log", "VL-Time-Field": "time", "VL-Stream-Fields": "namespace,container"}` }}
+  {{- $headers = deepCopy .Values.Fluentd.Output.Http.Headers }}
   {{- end }}
+  {{- if and .Values.Fluentd.Output.Http.Auth .Values.Fluentd.Output.Http.Auth.Token }}
+  {{- $_ := set $headers "Authorization" (printf "Bearer %s" .Values.Fluentd.Output.Http.Auth.TokenValue) }}
+  {{- end }}
+  headers      {{ $headers | toJson }}
   {{- if .Values.Fluentd.Output.Http.Routing }}
   {{- $logCategoryHeader := .Values.Fluentd.Output.Http.Routing.LogCategoryHeader | default "X-Log-Type" }}
   headers_from_placeholders {{ printf "{%s: \"${$.log_category}\"}" ($logCategoryHeader | quote) }}

--- a/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-loki.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-loki.conf
@@ -14,11 +14,11 @@
   </label>
   {{- if .Values.Fluentd.Output.Loki.Auth }}
   {{- if .Values.Fluentd.Output.Loki.Auth.Token }}
-  bearer_token_file "/fluentd/output/loki/auth/token"
+  bearer_token_file "/fluentd/etc/loki-auth-token"
   {{- end }}
   {{- if and .Values.Fluentd.Output.Loki.Auth.User .Values.Fluentd.Output.Loki.Auth.Password }}
-  username "#{ENV['LOKI_USERNAME']}"
-  password "#{ENV['LOKI_PASSWORD']}"
+  username {{ .Values.Fluentd.Output.Loki.Auth.UserValue | quote }}
+  password {{ .Values.Fluentd.Output.Loki.Auth.PasswordValue | quote }}
   {{- end }}
   {{- end }}
 

--- a/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-loki.conf
+++ b/controllers/fluentd/fluentd.configmap/conf.d/outputs/output-loki.conf
@@ -17,8 +17,8 @@
   bearer_token_file "/fluentd/etc/loki-auth-token"
   {{- end }}
   {{- if and .Values.Fluentd.Output.Loki.Auth.User .Values.Fluentd.Output.Loki.Auth.Password }}
-  username {{ .Values.Fluentd.Output.Loki.Auth.UserValue | quote }}
-  password {{ .Values.Fluentd.Output.Loki.Auth.PasswordValue | quote }}
+  username {{ .OutputCredentials.Loki.User | quote }}
+  password {{ .OutputCredentials.Loki.Password | quote }}
   {{- end }}
   {{- end }}
 

--- a/controllers/fluentd/handler.go
+++ b/controllers/fluentd/handler.go
@@ -14,12 +14,13 @@ import (
 )
 
 func (r *FluentdReconciler) handleConfigSecret(cr *loggingService.LoggingService) error {
-	if err := r.resolveOutputCredentials(cr); err != nil {
+	credentials, err := r.resolveOutputCredentials(cr)
+	if err != nil {
 		r.Log.Error(err, "Failed to resolve Fluentd output credentials")
 		return err
 	}
 
-	secret, err := fluentdConfigSecret(cr, r.DynamicParameters)
+	secret, err := fluentdConfigSecret(cr, r.DynamicParameters, credentials)
 	if err != nil {
 		r.Log.Error(err, "Failed creating Secret manifest")
 		return err
@@ -34,23 +35,28 @@ func (r *FluentdReconciler) handleConfigSecret(cr *loggingService.LoggingService
 	return nil
 }
 
-func (r *FluentdReconciler) resolveOutputCredentials(cr *loggingService.LoggingService) error {
+func (r *FluentdReconciler) resolveOutputCredentials(cr *loggingService.LoggingService) (outputCredentials, error) {
+	credentials := outputCredentials{}
 	if cr.Spec.Fluentd == nil || cr.Spec.Fluentd.Output == nil {
-		return nil
+		return credentials, nil
 	}
 	namespace := cr.GetNamespace()
 	output := cr.Spec.Fluentd.Output
-	if output.Loki != nil && output.Loki.Enabled {
-		if err := r.ResolveAuthValues(namespace, output.Loki.Auth); err != nil {
-			return err
+	if output.Loki != nil && output.Loki.Enabled && output.Loki.Auth != nil {
+		values, err := r.ResolveAuthValues(namespace, output.Loki.Auth)
+		if err != nil {
+			return outputCredentials{}, err
 		}
+		credentials.Loki = values
 	}
-	if output.Http != nil && output.Http.Enabled {
-		if err := r.ResolveAuthValues(namespace, output.Http.Auth); err != nil {
-			return err
+	if output.Http != nil && output.Http.Enabled && output.Http.Auth != nil {
+		values, err := r.ResolveAuthValues(namespace, output.Http.Auth)
+		if err != nil {
+			return outputCredentials{}, err
 		}
+		credentials.Http = values
 	}
-	return nil
+	return credentials, nil
 }
 
 func (r *FluentdReconciler) handleDaemonSet(cr *loggingService.LoggingService) error {
@@ -190,6 +196,7 @@ func (r *FluentdReconciler) createOrUpdateConfigSecret(cr *loggingService.Loggin
 			}
 
 			if !r.Equal(existedSecret, secret) {
+				secret.SetResourceVersion(existedSecret.GetResourceVersion())
 				if err = r.UpdateResource(secret); err != nil {
 					return false, err
 				}

--- a/controllers/fluentd/handler.go
+++ b/controllers/fluentd/handler.go
@@ -13,19 +13,43 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *FluentdReconciler) handleConfigMap(cr *loggingService.LoggingService) error {
-	m, err := fluentdConfigMap(cr, r.DynamicParameters)
-	if err != nil {
-		r.Log.Error(err, "Failed creating ConfigMap manifest")
+func (r *FluentdReconciler) handleConfigSecret(cr *loggingService.LoggingService) error {
+	if err := r.resolveOutputCredentials(cr); err != nil {
+		r.Log.Error(err, "Failed to resolve Fluentd output credentials")
 		return err
 	}
 
-	_, err = r.updateConfigMap(cr, m)
+	secret, err := fluentdConfigSecret(cr, r.DynamicParameters)
 	if err != nil {
-		r.Log.Error(err, fmt.Sprintf("Cannot create or update config map %s", m.Name))
+		r.Log.Error(err, "Failed creating Secret manifest")
 		return err
 	}
 
+	_, err = r.createOrUpdateConfigSecret(cr, secret)
+	if err != nil {
+		r.Log.Error(err, fmt.Sprintf("Cannot create or update config secret %s", secret.Name))
+		return err
+	}
+
+	return nil
+}
+
+func (r *FluentdReconciler) resolveOutputCredentials(cr *loggingService.LoggingService) error {
+	if cr.Spec.Fluentd == nil || cr.Spec.Fluentd.Output == nil {
+		return nil
+	}
+	namespace := cr.GetNamespace()
+	output := cr.Spec.Fluentd.Output
+	if output.Loki != nil && output.Loki.Enabled {
+		if err := r.ResolveAuthValues(namespace, output.Loki.Auth); err != nil {
+			return err
+		}
+	}
+	if output.Http != nil && output.Http.Enabled {
+		if err := r.ResolveAuthValues(namespace, output.Http.Auth); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -114,8 +138,8 @@ func (r *FluentdReconciler) deleteDaemonSet(cr *loggingService.LoggingService) e
 	return nil
 }
 
-func (r *FluentdReconciler) deleteConfigMap(cr *loggingService.LoggingService) error {
-	e := &corev1.ConfigMap{
+func (r *FluentdReconciler) deleteConfigSecret(cr *loggingService.LoggingService) error {
+	e := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.FluentdComponentName,
 			Namespace: cr.GetNamespace(),
@@ -152,29 +176,28 @@ func (r *FluentdReconciler) deleteService(cr *loggingService.LoggingService) err
 	return nil
 }
 
-func (r *FluentdReconciler) Equal(source *corev1.ConfigMap, target *corev1.ConfigMap) bool {
+func (r *FluentdReconciler) Equal(source, target *corev1.Secret) bool {
 	return cmp.Equal(source.Data, target.Data) &&
-		cmp.Equal(source.BinaryData, target.BinaryData) &&
 		cmp.Equal(source.GetLabels(), target.GetLabels())
 }
 
-func (r *FluentdReconciler) updateConfigMap(cr *loggingService.LoggingService, configMap *corev1.ConfigMap) (updated bool, err error) {
-	if err = r.CreateResource(cr, configMap); err != nil {
+func (r *FluentdReconciler) createOrUpdateConfigSecret(cr *loggingService.LoggingService, secret *corev1.Secret) (created bool, err error) {
+	if err = r.CreateResource(cr, secret); err != nil {
 		if errors.IsAlreadyExists(err) {
-			existedConfigMap := &corev1.ConfigMap{ObjectMeta: configMap.ObjectMeta}
-			if err = r.GetResource(existedConfigMap); err != nil {
+			existedSecret := &corev1.Secret{ObjectMeta: secret.ObjectMeta}
+			if err = r.GetResource(existedSecret); err != nil {
 				return false, err
 			}
 
-			if !r.Equal(existedConfigMap, configMap) {
-				if err = r.UpdateResource(configMap); err != nil {
+			if !r.Equal(existedSecret, secret) {
+				if err = r.UpdateResource(secret); err != nil {
 					return false, err
 				}
 
 				return true, nil
 			}
 
-			r.Log.Info("The config map is not changed")
+			r.Log.Info("The config secret is not changed")
 			return false, nil
 		}
 

--- a/controllers/fluentd/handler_test.go
+++ b/controllers/fluentd/handler_test.go
@@ -20,13 +20,13 @@ func TestFluentdEqual(t *testing.T) {
 	r := newTestFluentdReconciler()
 
 	t.Run("same data and labels returns true", func(t *testing.T) {
-		a := &corev1.ConfigMap{
+		a := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "fluentd"}},
-			Data:       map[string]string{"key": "value"},
+			Data:       map[string][]byte{"key": []byte("value")},
 		}
-		b := &corev1.ConfigMap{
+		b := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "fluentd"}},
-			Data:       map[string]string{"key": "value"},
+			Data:       map[string][]byte{"key": []byte("value")},
 		}
 		if !r.Equal(a, b) {
 			t.Error("expected equal for same data and labels")
@@ -34,21 +34,21 @@ func TestFluentdEqual(t *testing.T) {
 	})
 
 	t.Run("different data returns false", func(t *testing.T) {
-		a := &corev1.ConfigMap{Data: map[string]string{"key": "value1"}}
-		b := &corev1.ConfigMap{Data: map[string]string{"key": "value2"}}
+		a := &corev1.Secret{Data: map[string][]byte{"key": []byte("value1")}}
+		b := &corev1.Secret{Data: map[string][]byte{"key": []byte("value2")}}
 		if r.Equal(a, b) {
 			t.Error("expected not equal for different data")
 		}
 	})
 
 	t.Run("different labels returns false (fluentd checks labels)", func(t *testing.T) {
-		a := &corev1.ConfigMap{
+		a := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod"}},
-			Data:       map[string]string{"key": "value"},
+			Data:       map[string][]byte{"key": []byte("value")},
 		}
-		b := &corev1.ConfigMap{
+		b := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "dev"}},
-			Data:       map[string]string{"key": "value"},
+			Data:       map[string][]byte{"key": []byte("value")},
 		}
 		if r.Equal(a, b) {
 			t.Error("fluentd Equal should detect label changes, but it didn't")

--- a/controllers/fluentd/handler_test.go
+++ b/controllers/fluentd/handler_test.go
@@ -1,11 +1,16 @@
 package fluentd
 
 import (
+	"strings"
 	"testing"
 
+	loggingService "github.com/Netcracker/qubership-logging-operator/api/v1"
 	util "github.com/Netcracker/qubership-logging-operator/controllers/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func newTestFluentdReconciler() *FluentdReconciler {
@@ -54,4 +59,108 @@ func TestFluentdEqual(t *testing.T) {
 			t.Error("fluentd Equal should detect label changes, but it didn't")
 		}
 	})
+}
+
+func TestResolveOutputCredentials(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "output-auth", Namespace: "logging"},
+		Data: map[string][]byte{
+			"username": []byte("fluentd-user"),
+			"password": []byte("fluentd-password"),
+			"token":    []byte("fluentd-token"),
+		},
+	}
+	reconciler := &FluentdReconciler{
+		ComponentReconciler: &util.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build(),
+			Log:    util.Logger("test-fluentd"),
+		},
+	}
+	cr := &loggingService.LoggingService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "logging"},
+		Spec: loggingService.LoggingServiceSpec{
+			Fluentd: &loggingService.Fluentd{
+				Output: &loggingService.OutputFluentd{
+					Http: &loggingService.HttpFluentd{
+						Enabled: true,
+						Auth: &loggingService.Auth{
+							Token:    &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "output-auth"}, Key: "token"},
+							User:     &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "output-auth"}, Key: "username"},
+							Password: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "output-auth"}, Key: "password"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	credentials, err := reconciler.resolveOutputCredentials(cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentials.Http.Token != "fluentd-token" ||
+		credentials.Http.User != "fluentd-user" ||
+		credentials.Http.Password != "fluentd-password" {
+		t.Fatalf("unexpected resolved credentials: %#v", credentials.Http)
+	}
+
+	configSecret, err := fluentdConfigSecret(cr, util.DynamicParameters{}, credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpOutput := string(configSecret.Data["output-http.conf"])
+	for _, expected := range []string{"fluentd-user", "fluentd-password", "Bearer fluentd-token"} {
+		if !strings.Contains(httpOutput, expected) {
+			t.Errorf("generated HTTP output does not contain %q", expected)
+		}
+	}
+}
+
+func TestCreateOrUpdateConfigSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := loggingService.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "logging-fluentd", Namespace: "logging"},
+		Data:       map[string][]byte{"fluent.conf": []byte("old")},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := &FluentdReconciler{
+		ComponentReconciler: &util.ComponentReconciler{
+			Client: fakeClient,
+			Scheme: scheme,
+			Log:    util.Logger("test-fluentd"),
+		},
+	}
+	cr := &loggingService.LoggingService{
+		TypeMeta:   metav1.TypeMeta{APIVersion: loggingService.GroupVersion.String(), Kind: "LoggingService"},
+		ObjectMeta: metav1.ObjectMeta{Name: "logging-service", Namespace: "logging", UID: "test-uid"},
+	}
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "logging-fluentd", Namespace: "logging"},
+		Data:       map[string][]byte{"fluent.conf": []byte("new")},
+	}
+
+	updated, err := reconciler.createOrUpdateConfigSecret(cr, desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("expected the configuration Secret to be updated")
+	}
+	actual := &corev1.Secret{}
+	if err := fakeClient.Get(t.Context(), client.ObjectKeyFromObject(desired), actual); err != nil {
+		t.Fatal(err)
+	}
+	if string(actual.Data["fluent.conf"]) != "new" {
+		t.Fatalf("unexpected Secret data: %q", actual.Data["fluent.conf"])
+	}
 }

--- a/controllers/fluentd/manifest.go
+++ b/controllers/fluentd/manifest.go
@@ -19,12 +19,26 @@ var assets embed.FS
 //go:embed  fluentd.configmap/conf.d/*
 var configs embed.FS
 
-func fluentdConfigSecret(cr *loggingService.LoggingService, dynamicParameters util.DynamicParameters) (*corev1.Secret, error) {
+type outputCredentials struct {
+	Loki util.AuthValues
+	Http util.AuthValues
+}
+
+type fluentdTemplateParameters struct {
+	loggingService.LoggingServiceParameters
+	OutputCredentials outputCredentials
+}
+
+func fluentdConfigSecret(cr *loggingService.LoggingService, dynamicParameters util.DynamicParameters, credentials outputCredentials) (*corev1.Secret, error) {
 	if cr.Spec.Fluentd == nil {
 		return nil, fmt.Errorf("fluentd configuration in Logging Service %s is nil in the namespace %s", cr.GetName(), cr.GetNamespace())
 	}
 	cr.Spec.ContainerRuntimeType = dynamicParameters.ContainerRuntimeType
-	data, err := util.DataFromDirectory(configs, util.FluentdConfigMapDirectory, cr.ToParams())
+	parameters := fluentdTemplateParameters{
+		LoggingServiceParameters: cr.ToParams(),
+		OutputCredentials:        credentials,
+	}
+	data, err := util.DataFromDirectory(configs, util.FluentdConfigMapDirectory, parameters)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +49,7 @@ func fluentdConfigSecret(cr *loggingService.LoggingService, dynamicParameters ut
 
 	if output := cr.Spec.Fluentd.Output; output != nil && output.Loki != nil &&
 		output.Loki.Enabled && output.Loki.Auth != nil && output.Loki.Auth.Token != nil {
-		data["loki-auth-token"] = output.Loki.Auth.TokenValue
+		data["loki-auth-token"] = credentials.Loki.Token
 	}
 
 	secret := corev1.Secret{

--- a/controllers/fluentd/manifest.go
+++ b/controllers/fluentd/manifest.go
@@ -9,7 +9,7 @@ import (
 	util "github.com/Netcracker/qubership-logging-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -19,11 +19,10 @@ var assets embed.FS
 //go:embed  fluentd.configmap/conf.d/*
 var configs embed.FS
 
-func fluentdConfigMap(cr *loggingService.LoggingService, dynamicParameters util.DynamicParameters) (*corev1.ConfigMap, error) {
+func fluentdConfigSecret(cr *loggingService.LoggingService, dynamicParameters util.DynamicParameters) (*corev1.Secret, error) {
 	if cr.Spec.Fluentd == nil {
 		return nil, fmt.Errorf("fluentd configuration in Logging Service %s is nil in the namespace %s", cr.GetName(), cr.GetNamespace())
 	}
-	configMap := corev1.ConfigMap{}
 	cr.Spec.ContainerRuntimeType = dynamicParameters.ContainerRuntimeType
 	data, err := util.DataFromDirectory(configs, util.FluentdConfigMapDirectory, cr.ToParams())
 	if err != nil {
@@ -34,18 +33,29 @@ func fluentdConfigMap(cr *loggingService.LoggingService, dynamicParameters util.
 	data["filter-custom.conf"] = cr.Spec.Fluentd.CustomFilterConf
 	data["output-custom.conf"] = cr.Spec.Fluentd.CustomOutputConf
 
-	//Set parameters
-	configMap.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
-	configMap.SetName(util.FluentdComponentName)
-	configMap.SetNamespace(cr.GetNamespace())
-	configMap.Data = data
+	if output := cr.Spec.Fluentd.Output; output != nil && output.Loki != nil &&
+		output.Loki.Enabled && output.Loki.Auth != nil && output.Loki.Auth.Token != nil {
+		data["loki-auth-token"] = output.Loki.Auth.TokenValue
+	}
 
-	util.SetLabelsForResource(&configMap, util.LabelInput{
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.FluentdComponentName,
+			Namespace: cr.GetNamespace(),
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: util.StringMapToByteMap(data),
+	}
+	util.SetLabelsForResource(&secret, util.LabelInput{
 		Name:            util.FluentdComponentName,
 		Component:       "fluentd",
 		ComponentLabels: cr.Spec.Fluentd.Labels,
 	}, nil)
-	return &configMap, nil
+	return &secret, nil
 }
 
 func fluentdDaemonSet(cr *loggingService.LoggingService, dynamicParameters util.DynamicParameters) (*appsv1.DaemonSet, error) {

--- a/controllers/fluentd/reconciler.go
+++ b/controllers/fluentd/reconciler.go
@@ -27,7 +27,7 @@ func NewFluentdReconciler(client client.Client, scheme *runtime.Scheme, updater 
 }
 
 // Run reconciles fluentd custom resource.
-// Creates new DaemonSet, ConfigMap, Service if its don't exist.
+// Creates a DaemonSet, configuration Secret, and Service if they do not exist.
 func (r *FluentdReconciler) Run(cr *loggingService.LoggingService) error {
 	if !r.StatusUpdater.IsStatusFailed(util.FluentdStatus) {
 		r.StatusUpdater.UpdateStatus(util.FluentdStatus, util.InProgress, false, "Start reconcile of Fluentd")
@@ -35,7 +35,7 @@ func (r *FluentdReconciler) Run(cr *loggingService.LoggingService) error {
 	r.Log.Info("Start Fluentd reconciliation")
 
 	if cr.Spec.Fluentd != nil && cr.Spec.Fluentd.IsInstall() {
-		if err := r.handleConfigMap(cr); err != nil {
+		if err := r.handleConfigSecret(cr); err != nil {
 			return err
 		}
 		if err := r.handleDaemonSet(cr); err != nil {
@@ -65,8 +65,8 @@ func (r *FluentdReconciler) uninstall(cr *loggingService.LoggingService) {
 	if err := r.deleteDaemonSet(cr); err != nil {
 		r.Log.Error(err, "Can not delete DaemonSet")
 	}
-	if err := r.deleteConfigMap(cr); err != nil {
-		r.Log.Error(err, "Can not delete ConfigMap")
+	if err := r.deleteConfigSecret(cr); err != nil {
+		r.Log.Error(err, "Can not delete configuration Secret")
 	}
 	if err := r.deleteService(cr); err != nil {
 		r.Log.Error(err, "Can not delete Service")

--- a/controllers/loggingservice_controller.go
+++ b/controllers/loggingservice_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -20,8 +21,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -191,9 +194,61 @@ func (r *LoggingServiceReconciler) updateDynamicParameters(customResourceInstanc
 // SetupWithManager sets up the controller with the Manager.
 func (r *LoggingServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&loggingService.LoggingService{}).
-		WithEventFilter(ignoreDeletionPredicate()).
+		For(&loggingService.LoggingService{}, builder.WithPredicates(ignoreDeletionPredicate())).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.mapSecretToLoggingServices),
+			builder.WithPredicates(credentialSecretChangedPredicate()),
+		).
 		Complete(r)
+}
+
+func (r *LoggingServiceReconciler) mapSecretToLoggingServices(ctx context.Context, object client.Object) []reconcile.Request {
+	loggingServices := &loggingService.LoggingServiceList{}
+	if err := r.Client.List(ctx, loggingServices, client.InNamespace(object.GetNamespace())); err != nil {
+		r.Log.Error(err, "Cannot list Logging Services for changed Secret", "namespace", object.GetNamespace())
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(loggingServices.Items))
+	for i := range loggingServices.Items {
+		loggingServiceInstance := &loggingServices.Items[i]
+		if fluentdReferencesSecret(loggingServiceInstance, object.GetName()) {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(loggingServiceInstance),
+			})
+		}
+	}
+	return requests
+}
+
+func fluentdReferencesSecret(cr *loggingService.LoggingService, secretName string) bool {
+	if cr.Spec.Fluentd == nil || cr.Spec.Fluentd.Output == nil {
+		return false
+	}
+
+	output := cr.Spec.Fluentd.Output
+	return (output.Loki != nil && output.Loki.Enabled && authReferencesSecret(output.Loki.Auth, secretName)) ||
+		(output.Http != nil && output.Http.Enabled && authReferencesSecret(output.Http.Auth, secretName))
+}
+
+func authReferencesSecret(auth *loggingService.Auth, secretName string) bool {
+	if auth == nil {
+		return false
+	}
+	return (auth.Token != nil && auth.Token.Name == secretName) ||
+		(auth.User != nil && auth.User.Name == secretName) ||
+		(auth.Password != nil && auth.Password.Name == secretName)
+}
+
+func credentialSecretChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSecret, oldOK := e.ObjectOld.(*corev1.Secret)
+			newSecret, newOK := e.ObjectNew.(*corev1.Secret)
+			return oldOK && newOK && !reflect.DeepEqual(oldSecret.Data, newSecret.Data)
+		},
+	}
 }
 
 func ignoreDeletionPredicate() predicate.Predicate {

--- a/controllers/loggingservice_controller_test.go
+++ b/controllers/loggingservice_controller_test.go
@@ -1,13 +1,16 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	loggingService "github.com/Netcracker/qubership-logging-operator/api/v1"
+	util "github.com/Netcracker/qubership-logging-operator/controllers/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 var containerRuntimeTests = []struct {
@@ -187,5 +190,83 @@ func Test_updateDynamicParameters(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.containerRuntimeType, reconciler.DynamicParameters.ContainerRuntimeType)
 			}
 		})
+	}
+}
+
+func TestMapSecretToLoggingServices(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	if err := loggingService.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+
+	referenced := &loggingService.LoggingService{
+		ObjectMeta: metav1.ObjectMeta{Name: "referenced", Namespace: "logging"},
+		Spec: loggingService.LoggingServiceSpec{
+			Fluentd: &loggingService.Fluentd{
+				Output: &loggingService.OutputFluentd{
+					Http: &loggingService.HttpFluentd{
+						Enabled: true,
+						Auth: &loggingService.Auth{
+							Password: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "output-auth"},
+								Key:                  "password",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	unrelated := &loggingService.LoggingService{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "logging"},
+		Spec: loggingService.LoggingServiceSpec{
+			Fluentd: &loggingService.Fluentd{
+				Output: &loggingService.OutputFluentd{
+					Loki: &loggingService.LokiFluentd{
+						Enabled: true,
+						Auth: &loggingService.Auth{
+							Token: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "another-secret"},
+								Key:                  "token",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	reconciler := &LoggingServiceReconciler{
+		Client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced, unrelated).Build(),
+		Log:    util.Logger("test-logging-service"),
+	}
+
+	requests := reconciler.mapSecretToLoggingServices(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "output-auth", Namespace: "logging"},
+	})
+	if len(requests) != 1 || requests[0].Name != "referenced" || requests[0].Namespace != "logging" {
+		t.Fatalf("unexpected reconcile requests: %#v", requests)
+	}
+}
+
+func TestCredentialSecretChangedPredicate(t *testing.T) {
+	predicate := credentialSecretChangedPredicate()
+	oldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "output-auth", Namespace: "logging"},
+		Data:       map[string][]byte{"password": []byte("old")},
+	}
+
+	metadataOnly := oldSecret.DeepCopy()
+	metadataOnly.Labels = map[string]string{"updated": "true"}
+	if predicate.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: metadataOnly}) {
+		t.Fatal("metadata-only Secret update must not trigger reconciliation")
+	}
+
+	dataChanged := oldSecret.DeepCopy()
+	dataChanged.Data["password"] = []byte("new")
+	if !predicate.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: dataChanged}) {
+		t.Fatal("Secret data update must trigger reconciliation")
 	}
 }

--- a/controllers/utils/output_credentials.go
+++ b/controllers/utils/output_credentials.go
@@ -9,6 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// AuthValues contains credentials resolved for configuration rendering.
+type AuthValues struct {
+	Token    string
+	User     string
+	Password string
+}
+
 // StringMapToByteMap converts a map of strings to Secret data.
 func StringMapToByteMap(in map[string]string) map[string][]byte {
 	out := make(map[string][]byte, len(in))
@@ -34,31 +41,32 @@ func (r *ComponentReconciler) ResolveSecretKeyValue(namespace string, selector *
 	return string(value), nil
 }
 
-// ResolveAuthValues resolves Secret references into transient Auth fields.
-func (r *ComponentReconciler) ResolveAuthValues(namespace string, auth *loggingService.Auth) error {
+// ResolveAuthValues resolves output authentication Secret references.
+func (r *ComponentReconciler) ResolveAuthValues(namespace string, auth *loggingService.Auth) (AuthValues, error) {
 	if auth == nil {
-		return nil
+		return AuthValues{}, nil
 	}
+
+	values := AuthValues{}
+	var err error
+
 	if auth.Token != nil {
-		value, err := r.ResolveSecretKeyValue(namespace, auth.Token)
+		values.Token, err = r.ResolveSecretKeyValue(namespace, auth.Token)
 		if err != nil {
-			return err
+			return AuthValues{}, err
 		}
-		auth.TokenValue = value
 	}
 	if auth.User != nil {
-		value, err := r.ResolveSecretKeyValue(namespace, auth.User)
+		values.User, err = r.ResolveSecretKeyValue(namespace, auth.User)
 		if err != nil {
-			return err
+			return AuthValues{}, err
 		}
-		auth.UserValue = value
 	}
 	if auth.Password != nil {
-		value, err := r.ResolveSecretKeyValue(namespace, auth.Password)
+		values.Password, err = r.ResolveSecretKeyValue(namespace, auth.Password)
 		if err != nil {
-			return err
+			return AuthValues{}, err
 		}
-		auth.PasswordValue = value
 	}
-	return nil
+	return values, nil
 }

--- a/controllers/utils/output_credentials.go
+++ b/controllers/utils/output_credentials.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	loggingService "github.com/Netcracker/qubership-logging-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// StringMapToByteMap converts a map of strings to Secret data.
+func StringMapToByteMap(in map[string]string) map[string][]byte {
+	out := make(map[string][]byte, len(in))
+	for key, value := range in {
+		out[key] = []byte(value)
+	}
+	return out
+}
+
+// ResolveSecretKeyValue reads one referenced Secret value.
+func (r *ComponentReconciler) ResolveSecretKeyValue(namespace string, selector *corev1.SecretKeySelector) (string, error) {
+	if selector == nil {
+		return "", nil
+	}
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: selector.Name, Namespace: namespace}, secret); err != nil {
+		return "", fmt.Errorf("cannot read secret %q in namespace %q: %w", selector.Name, namespace, err)
+	}
+	value, ok := secret.Data[selector.Key]
+	if !ok || len(value) == 0 {
+		return "", fmt.Errorf("key %q not found or empty in secret %q in namespace %q", selector.Key, selector.Name, namespace)
+	}
+	return string(value), nil
+}
+
+// ResolveAuthValues resolves Secret references into transient Auth fields.
+func (r *ComponentReconciler) ResolveAuthValues(namespace string, auth *loggingService.Auth) error {
+	if auth == nil {
+		return nil
+	}
+	if auth.Token != nil {
+		value, err := r.ResolveSecretKeyValue(namespace, auth.Token)
+		if err != nil {
+			return err
+		}
+		auth.TokenValue = value
+	}
+	if auth.User != nil {
+		value, err := r.ResolveSecretKeyValue(namespace, auth.User)
+		if err != nil {
+			return err
+		}
+		auth.UserValue = value
+	}
+	if auth.Password != nil {
+		value, err := r.ResolveSecretKeyValue(namespace, auth.Password)
+		if err != nil {
+			return err
+		}
+		auth.PasswordValue = value
+	}
+	return nil
+}

--- a/docs/installation-parameters.md
+++ b/docs/installation-parameters.md
@@ -1679,6 +1679,10 @@ fluentd:
 
 <!-- markdownlint-enable line-length -->
 
+FluentD output authentication values are read from the referenced Kubernetes Secrets and written only to the generated
+FluentD configuration Secret. The operator watches these credential Secrets and regenerates the configuration after
+their data changes.
+
 Examples:
 
 **Note:** This is only an example of the parameters format, not a recommended value.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -941,10 +941,11 @@ in FluentD configuration. To do that you need to:
     kubectl scale -n <namespace> deployment logging-operator --replicas=0
     ```
 
-2. Edit configmap `logging-fluentd`.
+2. Edit Secret `logging-fluentd`. Configuration files are stored in the `data`
+   section as Base64-encoded values.
 
     ```bash
-    kubectl edit cm logging-fluentd -n <namespace>
+    kubectl edit secret logging-fluentd -n <namespace>
     ```
 
 3. Find part of configuration `output-graylog.conf`, in section `<buffer>` set the value:


### PR DESCRIPTION
Alternative way to resolve [issue](https://github.com/Netcracker/qubership-logging-operator/issues/198) for FluentD part.
An alternative method is based on the [comment](https://github.com/Netcracker/qubership-logging-operator/pull/274#discussion_r3550913701)
Also, the PR comment on fine-tuning the [new logic](https://github.com/Netcracker/qubership-logging-operator/pull/329#discussion_r3569622050) was taken.

**What was done**
Removed the «Secret → ENV» anti-pattern for FluentD and implemented the simplified approach from review: the entire config lives in a single Secret with inlined credentials, instead of separate auth Secret volumes, runtime File.read(), or credential env vars.

Auth is configured through SecretKeySelector refs in the CR (auth.token / auth.user / auth.password). The operator resolves referenced Secrets at reconcile time, injects values into the generated config, and stores the result in the FluentD configuration Secret. Credential Secret changes trigger automatic config regeneration without patching the CR.

**Mechanism**
During reconcile, the operator reads user Secrets via refs from the CR, keeps resolved values only in runtime render parameters, and generates the full FluentD config with credentials already substituted into the logging-fluentd Secret (replacing the previous ConfigMap). The DaemonSet mounts this Secret as its config.

Credential env vars (LOKI_*, HTTP_*) and the separate loki-auth-token auth volume are removed. TLS cert/key mounts are unchanged.
A secondary watch on credential Secrets reconciles affected LoggingService resources when Secret .data changes. Metadata-only Secret updates are ignored.

**FluentD specifics**
Loki bearer token is stored as loki-auth-token inside the same config Secret and referenced via bearer_token_file (FluentD Loki plugin requirement).
HTTP bearer token is inlined into the Authorization header in output-http.conf.
Loki/HTTP username and password are inlined into output templates from resolved Secret values.
Resolved credentials are not written back to the CR; the API keeps only Secret refs.

**Changed areas**
FluentD config storage — ConfigMap replaced with a single configuration Secret mounted by the DaemonSet.
Credential resolution — SecretKeySelector refs resolved at render time via shared operator helpers.
Configuration rendering — Loki/HTTP output templates use runtime resolved credentials instead of env vars or CR mutation.
DaemonSet layout — removed credential env blocks and separate auth volumes; one config Secret mount remains.
Credential rotation — watch on referenced credential Secrets with data-change filtering and CR mapping in the same namespace.
Reliability — configuration Secret updates preserve resourceVersion.
Tests — credential resolution, config rendering, Secret update flow, Secret-to-CR mapping, and watch predicate.
Documentation — troubleshooting and installation parameters updated for Secret-based config and automatic credential refresh.