### PR TITLE
chore(deps): use shared Renovate config

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,27 @@
+name: Validate Renovate Config
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json

--- a/deploy/kind/.env.example
+++ b/deploy/kind/.env.example
@@ -17,6 +17,7 @@ STORAGE_CLASS=local-path
 
 # qubership-opensearch chart release (used when BACKEND=graylog).
 # https://github.com/Netcracker/qubership-opensearch/releases
+# renovate: datasource=github-releases depName=Netcracker/qubership-opensearch versioning=semver
 OPENSEARCH_VERSION=2.3.0
 
 # VictoriaMetrics operator chart version (used when BACKEND=victorialogs).

--- a/deploy/kind/helmfile.yaml.gotmpl
+++ b/deploy/kind/helmfile.yaml.gotmpl
@@ -33,7 +33,7 @@ releases:
     namespace: opensearch
     createNamespace: true
     condition: backend.graylog.enabled
-    chart: https://github.com/Netcracker/qubership-opensearch/releases/download/{{ env "OPENSEARCH_VERSION" | default "2.3.0" }}/opensearch-{{ env "OPENSEARCH_VERSION" | default "2.3.0" }}.tgz
+    chart: https://github.com/Netcracker/qubership-opensearch/releases/download/{{ requiredEnv "OPENSEARCH_VERSION" }}/opensearch-{{ requiredEnv "OPENSEARCH_VERSION" }}.tgz
     values:
       - values-opensearch.yaml
       - opensearch:

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
     "github>Netcracker/renovate-config:annotated-versions"
   ],
   "prConcurrentLimit": 20,
+  "ignorePaths": [
+    "deploy/kind/helmfile.yaml.gotmpl"
+  ],
   "packageRules": [
     {
       "matchManagers": ["custom.regex"],
@@ -72,7 +75,7 @@
         "Dockerfile",
         "tests/robot-tests/Dockerfile"
       ],
-      "matchPackageNames": ["*"]
+      "matchPackageNames": ["!golang"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -75,7 +75,6 @@
         "Dockerfile"
       ],
       "matchPackageNames": [
-        "!alpine",
         "!golang",
         "!docker.io/library/golang",
         "!index.docker.io/library/golang",

--- a/renovate.json
+++ b/renovate.json
@@ -75,6 +75,7 @@
         "Dockerfile"
       ],
       "matchPackageNames": [
+        "!alpine",
         "!golang",
         "!docker.io/library/golang",
         "!index.docker.io/library/golang",

--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "schedule:weekly"
-  ],
-  "labels": [
-    "dependencies"
+    "github>Netcracker/renovate-config:base",
+    "github>Netcracker/renovate-config:github-actions",
+    "github>Netcracker/renovate-config:go",
+    "github>Netcracker/renovate-config:netcracker-dependencies",
+    "github>Netcracker/renovate-config:annotated-versions"
   ],
   "prConcurrentLimit": 20,
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Update versions via inline renovate annotation comments",
-      "managerFilePatterns": [
-        "/controllers/fluentd/fluentd\\.configmap/conf\\.d/outputs/output-prometheus\\.conf/",
-        "/charts/qubership-logging-operator/templates/_helpers\\.tpl/",
-        "/charts/qubership-logging-operator/values\\.yaml/",
-        "/.github/workflows/integration-tests\\.yml/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z-0-9]+))?[^\\n]*\\n[^\\n]*?(?<currentValue>[0-9][^\\s\"'\\n<]*)"
-      ],
-      "extractVersionTemplate": "^v?(?<version>.+)$"
-    }
-  ],
   "packageRules": [
     {
       "matchManagers": ["custom.regex"],
@@ -80,21 +64,6 @@
         "alpine"
       ],
       "groupName": "third-party-images"
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "actions-deps",
-      "matchPackageNames": ["*"]
-    },
-    {
-      "matchManagers": ["gomod"],
-      "groupName": "k8s.io",
-      "matchPackageNames": ["k8s.io/{/,}**"]
-    },
-    {
-      "matchManagers": ["gomod"],
-      "groupName": "go.opentelemetry.io",
-      "matchPackageNames": ["go.opentelemetry.io/{/,}**"]
     },
     {
       "matchManagers": ["dockerfile"],

--- a/renovate.json
+++ b/renovate.json
@@ -75,7 +75,12 @@
         "Dockerfile",
         "tests/robot-tests/Dockerfile"
       ],
-      "matchPackageNames": ["!golang"]
+      "matchPackageNames": [
+        "!golang",
+        "!docker.io/library/golang",
+        "!index.docker.io/library/golang",
+        "!registry-1.docker.io/library/golang"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -72,8 +72,7 @@
       "matchManagers": ["dockerfile"],
       "groupName": "docker-deps",
       "matchFileNames": [
-        "Dockerfile",
-        "tests/robot-tests/Dockerfile"
+        "Dockerfile"
       ],
       "matchPackageNames": [
         "!golang",


### PR DESCRIPTION
## Why

The repository duplicates shared Renovate rules, and the local development Helmfile cannot be parsed within Renovate's repository file-access boundary.

## What

- Use the shared base, GitHub Actions, Go, Netcracker dependency, and annotated-version presets.
- Preserve repository-specific Go, Docker, and annotated dependency groups.
- Track the local OpenSearch version in `.env.example` and consume it from the ignored development Helmfile.
- Remove a stale Dockerfile selector and validate `renovate.json` in CI.

Related shared configuration: [Netcracker/renovate-config#29](https://github.com/Netcracker/renovate-config/pull/29) and [Netcracker/renovate-config#31](https://github.com/Netcracker/renovate-config/pull/31).