### PR TITLE
fix(renovate): constrain Graylog image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,12 @@
     },
     {
       "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["graylog/graylog"],
+      "matchCurrentVersion": "/^5\\./",
+      "allowedVersions": ">=5.0.0 <6.0.0"
+    },
+    {
+      "matchManagers": ["custom.regex"],
       "matchPackageNames": ["mongo"],
       "matchCurrentVersion": "/^5\\./",
       "allowedVersions": ">=5.0.0 <6.0.0"
@@ -66,7 +72,8 @@
         "mongo",
         "alpine"
       ],
-      "groupName": "third-party-images"
+      "groupName": "third-party-images",
+      "pinDigests": false
     },
     {
       "matchManagers": ["dockerfile"],


### PR DESCRIPTION
## Why

Renovate proposes Graylog 7.x even though the operator handles Graylog 5.x. It also fails to create the `third-party-images` branch because tag-only Helm annotations cannot store pinned digests.

## What changed

- Limit `graylog/graylog` updates to 5.x.
- Disable digest pinning for the tag-only `custom.regex` image group.

This resolves the update failure reported in [Dependency Dashboard #236](https://github.com/Netcracker/qubership-logging-operator/issues/236).

## Validation

- Strict Renovate configuration validation
- `actionlint`
- Independent rule evaluation against Graylog, MongoDB, Dockerfile, and Helm dependencies
